### PR TITLE
ci: add GitHub Actions workflow to run pnpm tests on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Run the Vitest suite from the repo root:
 pnpm test
 ```
 
+Pull requests run `pnpm test` automatically in CI.
+
 Watch mode:
 
 ```bash


### PR DESCRIPTION
### Motivation
- Ensure every Pull Request runs the monorepo unit test suite to catch regressions early.
- Use the repo's pnpm/Turborepo layout and existing root `pnpm test` script as the single source of truth for tests.
- Keep installs fast and deterministic by using `pnpm` with a frozen lockfile and cache support.
- Run tests on PRs and on pushes to `main` to protect the main branch.

### Description
- Added `.github/workflows/tests.yml` which triggers on `pull_request` and `push` to `main` and runs tests from the repo root.
- The workflow checks out the repo, sets up `pnpm` (pinned to `9.12.3` per `package.json`), and sets up Node.js `20` with `pnpm` caching via `actions/setup-node@v4`.
- It installs dependencies with `pnpm install --frozen-lockfile` and runs the test suite with `pnpm test` so failures cause the job to fail.
- Updated `README.md` under the Testing section to note that Pull Requests run `pnpm test` automatically in CI.

### Testing
- No automated tests were executed locally; the change adds CI automation that runs tests on GitHub Actions.
- The workflow will execute `pnpm test` in CI and the job will fail if the test suite fails.
- The workflow file was created and verified as valid YAML and placed at `.github/workflows/tests.yml`.
- Local repository sanity checks (file creation and commit) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e0563303c8329a52bb0e7eed371ce)