### PR TITLE
refactor(evrydayarchive-web): import prisma from @repo/db and add workspace typecheck scripts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,5 +29,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run lint
+        run: pnpm lint
+
+      - name: Run typecheck
+        run: pnpm typecheck
+
+      - name: Run build
+        run: pnpm build
+
       - name: Run tests
         run: pnpm test

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit --incremental false",
     "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {

--- a/apps/evrydayarchive-web/app/api/galleries/[slug]/route.ts
+++ b/apps/evrydayarchive-web/app/api/galleries/[slug]/route.ts
@@ -1,5 +1,5 @@
 import { createApiError, jsonError, jsonOk } from '@repo/core';
-import { prisma } from '../../../lib/db';
+import { prisma } from '@repo/db';
 import { getPublicEnv } from '../../../lib/env';
 
 export const GET = async (

--- a/apps/evrydayarchive-web/app/api/galleries/route.ts
+++ b/apps/evrydayarchive-web/app/api/galleries/route.ts
@@ -1,5 +1,5 @@
 import { createApiError, jsonError, jsonOk } from '@repo/core';
-import { prisma } from '../../lib/db';
+import { prisma } from '@repo/db';
 import { getPublicEnv } from '../../lib/env';
 
 export const GET = async (): Promise<Response> => {

--- a/apps/evrydayarchive-web/app/lib/db.ts
+++ b/apps/evrydayarchive-web/app/lib/db.ts
@@ -1,3 +1,0 @@
-import { prisma } from '@repo/db';
-
-export { prisma };

--- a/apps/evrydayarchive-web/app/portfolio/[slug]/page.tsx
+++ b/apps/evrydayarchive-web/app/portfolio/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
 
-import { prisma } from '../../lib/db';
+import { prisma } from '@repo/db';
 import { getPublicEnv } from '../../lib/env';
 
 const GalleryDetailPage = async ({ params }: { params: { slug: string } }) => {

--- a/apps/evrydayarchive-web/app/portfolio/page.tsx
+++ b/apps/evrydayarchive-web/app/portfolio/page.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { prisma } from '../lib/db';
+import { prisma } from '@repo/db';
 import { getPublicEnv } from '../lib/env';
 
 const PortfolioPage = async () => {

--- a/apps/evrydayarchive-web/package.json
+++ b/apps/evrydayarchive-web/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit --incremental false",
     "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {

--- a/apps/reed-web/package.json
+++ b/apps/reed-web/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit --incremental false",
     "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "turbo run dev --parallel",
     "build": "turbo run build",
     "lint": "turbo run lint",
+    "typecheck": "turbo run typecheck",
     "format": "prettier --write .",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
+    "typecheck": "tsc --noEmit --incremental false",
     "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,6 +17,7 @@
     "db:reset:force": "prisma migrate reset --force",
     "db:studio": "prisma studio",
     "db:status": "prisma migrate status",
+    "typecheck": "tsc --noEmit --incremental false",
     "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
+    "typecheck": "tsc --noEmit --incremental false",
     "test": "vitest run --config ../../vitest.config.ts"
   },
   "peerDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,9 @@
     },
     "lint": {
       "dependsOn": ["^lint"]
+    },
+    "typecheck": {
+      "dependsOn": ["^typecheck"]
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Consolidate Prisma usage to the central `@repo/db` package to match the `admin` app and avoid app-level re-exports.
- Remove the redundant app-level `lib/db.ts` helper to simplify imports and reduce indirection.
- Prevent generation of `.tsbuildinfo` during CI type checks by running `tsc --noEmit --incremental false` in each workspace.
- Ensure type checks run across the monorepo via `turbo` and the CI pipeline before tests.

### Description
- Replaced local `lib/db` imports with `@repo/db` in `apps/evrydayarchive-web` API and page files and deleted `apps/evrydayarchive-web/app/lib/db.ts`.
- Added per-package `typecheck` scripts using `tsc --noEmit --incremental false` to `apps/admin`, `apps/evrydayarchive-web`, `apps/reed-web`, `packages/core`, `packages/db`, and `packages/ui` and added a root `typecheck` script in `package.json` that runs `turbo run typecheck`.
- Updated `turbo.json` to add a `typecheck` task that depends on `^typecheck` for workspace execution.
- Updated the CI workflow `.github/workflows/tests.yml` to run `pnpm lint`, `pnpm typecheck`, and `pnpm build` prior to `pnpm test`.

### Testing
- No automated tests were executed as part of this change.
- The repository CI is configured to run `pnpm lint`, `pnpm typecheck`, `pnpm build`, and `pnpm test` on push/PR to validate the updates.
- The code changes were applied and staged in the working tree successfully for review.
- Any CI failures will be addressed in follow-up fixes as needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602863d2fc83299db47ef3111f7801)