### PR TITLE
test(core): expand API guardrail coverage

### DIFF
--- a/apps/evrydayarchive-web/app/api/galleries/route.errors.test.ts
+++ b/apps/evrydayarchive-web/app/api/galleries/route.errors.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { PublicApiError, fetchPublicGalleries } from '@repo/core';
+
+vi.mock('@repo/core', async () => {
+  const actual = await vi.importActual<typeof import('@repo/core')>('@repo/core');
+  return {
+    ...actual,
+    fetchPublicGalleries: vi.fn()
+  };
+});
+
+vi.mock('../../lib/env', () => ({
+  getServerEnv: () => ({ ADMIN_API_BASE_URL: 'https://api.example.test' })
+}));
+
+describe('GET /api/galleries error handling', () => {
+  it('returns the upstream error payload for PublicApiError', async () => {
+    vi.mocked(fetchPublicGalleries).mockRejectedValueOnce(
+      new PublicApiError('Failed to load galleries.', 502, { message: 'Bad gateway' })
+    );
+
+    const { GET } = await import('./route');
+
+    const response = await GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(payload).toEqual({
+      message: 'Failed to load galleries.',
+      details: { message: 'Bad gateway' }
+    });
+  });
+});

--- a/packages/core/src/api/publicGalleries.test.ts
+++ b/packages/core/src/api/publicGalleries.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  PublicApiError,
+  fetchPublicGalleries,
+  fetchPublicGalleryDetail
+} from './publicGalleries';
+
+const galleryListResponse = [
+  {
+    id: 'gallery-1',
+    slug: 'fall-highlights',
+    title: 'Fall Highlights',
+    location: 'Austin, TX',
+    coverImage: { src: 'https://example.com/cover.jpg', alt: 'Cover' },
+    imageCount: 12
+  }
+];
+
+const galleryDetailResponse = {
+  id: 'gallery-1',
+  slug: 'fall-highlights',
+  title: 'Fall Highlights',
+  description: null,
+  location: 'Austin, TX',
+  images: [
+    {
+      id: 'image-1',
+      order: 0,
+      src: 'https://example.com/photo.jpg',
+      alt: 'Photo',
+      caption: null
+    }
+  ]
+};
+
+describe('public gallery API helpers', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches and parses the gallery list', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(galleryListResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+
+    const result = await fetchPublicGalleries('https://api.example.test');
+
+    expect(result).toEqual(galleryListResponse);
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL('/api/public/galleries', 'https://api.example.test'),
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('fetches and parses a gallery detail', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(galleryDetailResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+
+    const result = await fetchPublicGalleryDetail(
+      'https://api.example.test',
+      'fall-highlights'
+    );
+
+    expect(result).toEqual(galleryDetailResponse);
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL('/api/public/galleries/fall-highlights', 'https://api.example.test'),
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('throws a PublicApiError when the response is not ok', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'Nope' }), {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+
+    await expect(fetchPublicGalleries('https://api.example.test')).rejects.toEqual(
+      expect.objectContaining({
+        name: 'PublicApiError',
+        message: 'Failed to load galleries.',
+        status: 503,
+        details: { message: 'Nope' }
+      })
+    );
+  });
+
+  it('throws a PublicApiError when the response schema does not match', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'missing-fields' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+
+    await expect(fetchPublicGalleries('https://api.example.test')).rejects.toEqual(
+      expect.objectContaining({
+        name: 'PublicApiError',
+        message: 'Gallery list response did not match the expected schema.'
+      })
+    );
+  });
+
+  it('throws a PublicApiError when JSON parsing fails', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response('not-json', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+
+    await expect(fetchPublicGalleries('https://api.example.test')).rejects.toEqual(
+      expect.objectContaining({
+        name: 'PublicApiError',
+        message: 'Failed to parse API response JSON.'
+      })
+    );
+  });
+});

--- a/packages/core/src/api/response.test.ts
+++ b/packages/core/src/api/response.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { jsonError, jsonOk } from './response';
+
+describe('jsonOk', () => {
+  it('wraps data in an ok response', async () => {
+    const response = jsonOk({ message: 'hello' }, { status: 201 });
+    const payload = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(payload).toEqual({ ok: true, data: { message: 'hello' } });
+  });
+});
+
+describe('jsonError', () => {
+  it('uses the default status from the error map', async () => {
+    const response = jsonError({ code: 'NOT_FOUND', message: 'Missing' });
+    const payload = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(payload).toEqual({
+      ok: false,
+      error: { code: 'NOT_FOUND', message: 'Missing' }
+    });
+  });
+
+  it('respects an explicit status override', async () => {
+    const response = jsonError({ code: 'INTERNAL', message: 'Boom' }, 503);
+
+    expect(response.status).toBe(503);
+  });
+});

--- a/packages/core/src/env.test.ts
+++ b/packages/core/src/env.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { loadEnv } from './env';
+
+describe('loadEnv', () => {
+  it('returns validated env data', () => {
+    const schema = z.object({
+      ADMIN_PASSWORD: z.string().min(1),
+      AUTH_SECRET: z.string().min(1)
+    });
+
+    const result = loadEnv(schema, {
+      ADMIN_PASSWORD: 'password',
+      AUTH_SECRET: 'secret'
+    });
+
+    expect(result).toEqual({
+      ADMIN_PASSWORD: 'password',
+      AUTH_SECRET: 'secret'
+    });
+  });
+
+  it('throws a helpful error when validation fails', () => {
+    const schema = z.object({
+      ADMIN_PASSWORD: z.string().min(1),
+      AUTH_SECRET: z.string().min(1)
+    });
+
+    expect(() => loadEnv(schema, { ADMIN_PASSWORD: '' })).toThrow(
+      'Invalid environment variables'
+    );
+  });
+});


### PR DESCRIPTION
### Motivation

- Improve confidence around API guardrails and error handling for public-facing helpers and routes by adding focused unit tests.  
- Make upstream failure modes deterministic in tests by mocking network and dependency boundaries.  

### Description

- Added unit tests for response helpers in `packages/core/src/api/response.test.ts` that verify `jsonOk` and `jsonError` behavior.  
- Added tests for public gallery fetch helpers in `packages/core/src/api/publicGalleries.test.ts` that cover successful list/detail parsing, non-OK responses, schema mismatches, and JSON parse failures.  
- Added env validation tests in `packages/core/src/env.test.ts` for `loadEnv`.  
- Added a route-level error handling test `apps/evrydayarchive-web/app/api/galleries/route.errors.test.ts` which mocks `@repo/core` and the server env helper to assert proper propagation of `PublicApiError`.  
- Mocking strategy: network calls are stubbed with `vi.stubGlobal('fetch')` and `vi.mocked(globalThis.fetch)` returning `Response` instances for deterministic scenarios; dependency boundaries are mocked with `vi.mock('@repo/core', ...)` and `vi.mock('../../lib/env', ...)` to simulate upstream errors without modifying application code.  

### Testing

- Ran `pnpm lint` at the repo root and the lint step completed successfully.  
- Ran `pnpm build` which failed during `evrydayarchive-web` prerendering due to a missing required environment variable `ADMIN_API_BASE_URL` (error: "Invalid environment variables: ADMIN_API_BASE_URL: Required").  
- Added tests are present under `packages/core/src/api/*` and `apps/evrydayarchive-web/app/api/*` (not executed as part of this PR run); they rely on the mocking strategy described above for deterministic unit testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987e2dbfe488329891ab12d68cc25fd)