### PR TITLE
chore(repo): format pull request template markdown

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## PR Checklist
+
+### 1) Summary of scope
+
+- [ ] Briefly describe what changed (and what did **not** change).
+- [ ] List affected apps/packages.
+
+### 2) Why this change is needed
+
+- [ ] Explain the user or engineering problem this PR solves.
+- [ ] Link issue/ticket/spec (if applicable).
+
+### 3) Local validation evidence
+
+> Keep this aligned with CI in `.github/workflows/tests.yml`.
+
+- [ ] `pnpm lint` — outcome: <!-- pass/fail + key notes -->
+- [ ] `pnpm build` — outcome: <!-- pass/fail + key notes -->
+- [ ] Relevant app sanity check(s) — outcome: <!-- e.g., `pnpm --filter <app> dev` + manual smoke result -->
+
+Optional CI-parity checks (recommended when relevant):
+
+- [ ] `pnpm typecheck` — outcome:
+- [ ] `pnpm format:check` — outcome:
+- [ ] `pnpm test` — outcome:
+
+### 4) Risk / rollback notes
+
+- [ ] Risk level: <!-- low/medium/high -->
+- [ ] Main risks and impacted areas:
+- [ ] Rollback plan (revert steps, flags, or migrations):
+
+### 5) Follow-ups
+
+- [ ] None.
+- [ ] If needed, list follow-up tasks with owner and scope.


### PR DESCRIPTION
### Motivation
- Apply consistent Prettier formatting to the repository PR template so markdown whitespace and blank-line style align with project conventions.

### Description
- Ran Prettier on `.github/pull_request_template.md`, normalizing blank lines between section headers and checklist items without changing checklist content or intent.

### Testing
- Ran `pnpm prettier --write .github/pull_request_template.md` and the formatting command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699933a6aa84832998ce6ae3cebbae42)