### PR TITLE
feat(db): add Q1 Package, PackageModifier, TimeSlot, Inquiry, and BookingRequest Prisma models

### DIFF
--- a/packages/db/prisma/migrations/20260222120000_add_q1_entities/migration.sql
+++ b/packages/db/prisma/migrations/20260222120000_add_q1_entities/migration.sql
@@ -1,0 +1,133 @@
+-- CreateEnum
+CREATE TYPE "PackageStatus" AS ENUM ('DRAFT', 'ACTIVE', 'ARCHIVED');
+
+-- CreateEnum
+CREATE TYPE "TimeSlotStatus" AS ENUM ('AVAILABLE', 'HELD', 'UNAVAILABLE');
+
+-- CreateEnum
+CREATE TYPE "InquiryType" AS ENUM ('GENERAL', 'PACKAGE_BUILDER', 'BOOKING_REQUEST');
+
+-- CreateEnum
+CREATE TYPE "InquiryStatus" AS ENUM ('NEW', 'IN_REVIEW', 'RESOLVED', 'ARCHIVED');
+
+-- CreateEnum
+CREATE TYPE "BookingRequestStatus" AS ENUM ('PENDING', 'REVIEWED', 'APPROVED', 'DECLINED', 'CANCELLED');
+
+-- CreateTable
+CREATE TABLE "Package" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "basePriceCents" INTEGER,
+    "status" "PackageStatus" NOT NULL DEFAULT 'DRAFT',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Package_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PackageModifier" (
+    "id" TEXT NOT NULL,
+    "packageId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "priceDeltaCents" INTEGER,
+    "isRequired" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PackageModifier_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TimeSlot" (
+    "id" TEXT NOT NULL,
+    "startsAt" TIMESTAMP(3) NOT NULL,
+    "endsAt" TIMESTAMP(3) NOT NULL,
+    "status" "TimeSlotStatus" NOT NULL DEFAULT 'AVAILABLE',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TimeSlot_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Inquiry" (
+    "id" TEXT NOT NULL,
+    "type" "InquiryType" NOT NULL,
+    "status" "InquiryStatus" NOT NULL DEFAULT 'NEW',
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "phone" TEXT,
+    "message" TEXT,
+    "payload" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Inquiry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BookingRequest" (
+    "id" TEXT NOT NULL,
+    "inquiryId" TEXT,
+    "packageId" TEXT,
+    "timeSlotId" TEXT,
+    "status" "BookingRequestStatus" NOT NULL DEFAULT 'PENDING',
+    "guestCount" INTEGER,
+    "requestedAt" TIMESTAMP(3),
+    "notes" TEXT,
+    "selectedOptions" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BookingRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Package_slug_key" ON "Package"("slug");
+
+-- CreateIndex
+CREATE INDEX "PackageModifier_packageId_idx" ON "PackageModifier"("packageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PackageModifier_packageId_name_key" ON "PackageModifier"("packageId", "name");
+
+-- CreateIndex
+CREATE INDEX "TimeSlot_startsAt_idx" ON "TimeSlot"("startsAt");
+
+-- CreateIndex
+CREATE INDEX "TimeSlot_status_idx" ON "TimeSlot"("status");
+
+-- CreateIndex
+CREATE INDEX "Inquiry_type_idx" ON "Inquiry"("type");
+
+-- CreateIndex
+CREATE INDEX "Inquiry_status_idx" ON "Inquiry"("status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BookingRequest_inquiryId_key" ON "BookingRequest"("inquiryId");
+
+-- CreateIndex
+CREATE INDEX "BookingRequest_packageId_idx" ON "BookingRequest"("packageId");
+
+-- CreateIndex
+CREATE INDEX "BookingRequest_status_idx" ON "BookingRequest"("status");
+
+-- CreateIndex
+CREATE INDEX "BookingRequest_timeSlotId_idx" ON "BookingRequest"("timeSlotId");
+
+-- AddForeignKey
+ALTER TABLE "PackageModifier" ADD CONSTRAINT "PackageModifier_packageId_fkey" FOREIGN KEY ("packageId") REFERENCES "Package"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BookingRequest" ADD CONSTRAINT "BookingRequest_inquiryId_fkey" FOREIGN KEY ("inquiryId") REFERENCES "Inquiry"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BookingRequest" ADD CONSTRAINT "BookingRequest_packageId_fkey" FOREIGN KEY ("packageId") REFERENCES "Package"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BookingRequest" ADD CONSTRAINT "BookingRequest_timeSlotId_fkey" FOREIGN KEY ("timeSlotId") REFERENCES "TimeSlot"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -13,6 +13,39 @@ enum GalleryStatus {
   ARCHIVED
 }
 
+enum PackageStatus {
+  DRAFT
+  ACTIVE
+  ARCHIVED
+}
+
+enum TimeSlotStatus {
+  AVAILABLE
+  HELD
+  UNAVAILABLE
+}
+
+enum InquiryType {
+  GENERAL
+  PACKAGE_BUILDER
+  BOOKING_REQUEST
+}
+
+enum InquiryStatus {
+  NEW
+  IN_REVIEW
+  RESOLVED
+  ARCHIVED
+}
+
+enum BookingRequestStatus {
+  PENDING
+  REVIEWED
+  APPROVED
+  DECLINED
+  CANCELLED
+}
+
 model Gallery {
   id          String        @id @default(cuid())
   slug        String        @unique
@@ -51,4 +84,83 @@ model GalleryImage {
 
   @@unique([galleryId, imageAssetId])
   @@index([galleryId])
+}
+
+model Package {
+  id              String            @id @default(cuid())
+  slug            String            @unique
+  name            String
+  description     String?
+  basePriceCents  Int?
+  status          PackageStatus     @default(DRAFT)
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
+  modifiers       PackageModifier[]
+  bookingRequests BookingRequest[]
+}
+
+model PackageModifier {
+  id              String   @id @default(cuid())
+  packageId       String
+  name            String
+  description     String?
+  priceDeltaCents Int?
+  isRequired      Boolean  @default(false)
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  package         Package  @relation(fields: [packageId], references: [id], onDelete: Cascade)
+
+  @@index([packageId])
+  @@unique([packageId, name])
+}
+
+model TimeSlot {
+  id              String            @id @default(cuid())
+  startsAt        DateTime
+  endsAt          DateTime
+  status          TimeSlotStatus    @default(AVAILABLE)
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
+  bookingRequests BookingRequest[]
+
+  @@index([startsAt])
+  @@index([status])
+}
+
+model Inquiry {
+  id             String        @id @default(cuid())
+  type           InquiryType
+  status         InquiryStatus @default(NEW)
+  name           String
+  email          String
+  phone          String?
+  message        String?
+  payload        Json?
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+  bookingRequest BookingRequest?
+
+  @@index([type])
+  @@index([status])
+}
+
+model BookingRequest {
+  id              String               @id @default(cuid())
+  inquiryId       String?              @unique
+  packageId       String?
+  timeSlotId      String?
+  status          BookingRequestStatus @default(PENDING)
+  guestCount      Int?
+  requestedAt     DateTime?
+  notes           String?
+  selectedOptions Json?
+  createdAt       DateTime             @default(now())
+  updatedAt       DateTime             @updatedAt
+  inquiry         Inquiry?             @relation(fields: [inquiryId], references: [id], onDelete: SetNull)
+  package         Package?             @relation(fields: [packageId], references: [id], onDelete: SetNull)
+  timeSlot        TimeSlot?            @relation(fields: [timeSlotId], references: [id], onDelete: SetNull)
+
+  @@index([packageId])
+  @@index([status])
+  @@index([timeSlotId])
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,11 +1,21 @@
 export { prisma } from './client';
 export { getDbEnv } from './env';
 export type {
+  BookingRequest,
+  BookingRequestStatus,
   Gallery,
   GalleryImage,
-  ImageAsset,
   GalleryStatus,
-  Prisma as PrismaTypes
+  ImageAsset,
+  Inquiry,
+  InquiryStatus,
+  InquiryType,
+  Package,
+  PackageModifier,
+  PackageStatus,
+  Prisma as PrismaTypes,
+  TimeSlot,
+  TimeSlotStatus
 } from '@prisma/client';
 export { Prisma } from '@prisma/client';
 export { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';


### PR DESCRIPTION
### Motivation

- Introduce the missing Q1 roadmap entities so apps can model packages, modifiers, availability slots, inquiries, and booking requests in the database.
- Provide consistent lifecycle/type enums and `createdAt`/`updatedAt` timestamps across new models for predictable status handling and auditing.

### Description

- Added Prisma enums `PackageStatus`, `TimeSlotStatus`, `InquiryType`, `InquiryStatus`, and `BookingRequestStatus` to `packages/db/prisma/schema.prisma`.
- Added models `Package`, `PackageModifier`, `TimeSlot`, `Inquiry`, and `BookingRequest` with fields, relations, indexes, and consistent `createdAt` / `updatedAt` timestamps in `packages/db/prisma/schema.prisma`.
- Generated migration SQL capturing enum/table/index/foreign-key changes and added it as `packages/db/prisma/migrations/20260222120000_add_q1_entities/migration.sql` (generated using `prisma migrate diff` since runtime DB env was not available).
- Updated `packages/db/src/index.ts` to export the new Prisma model and enum types for downstream usage (`Package`, `PackageModifier`, `TimeSlot`, `Inquiry`, `BookingRequest`, and related enums/status types).

### Testing

- Ran `pnpm --filter @repo/db db:generate` / `prisma generate` successfully to refresh the Prisma client for the new schema.
- Ran repository linting with `pnpm lint` and it completed successfully.
- Attempting `prisma migrate dev` was not possible in this environment because `DATABASE_URL` is not set, so the migration SQL was produced with `prisma migrate diff` instead.
- Running `pnpm build` in this workspace surfaced an unrelated build-time missing `DATABASE_URL` error in `apps/admin` (failure due to environment limitations, not schema changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b9550d94c8329bcdba3e8ef32c63b)