### PR TITLE
feat(core): add booking & package Zod schemas with tests

### DIFF
--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 
+export * from './schemas/admin-packages';
+export * from './schemas/booking-request';
 export * from './schemas/gallery';
+export * from './schemas/inquiry';
+export * from './schemas/package-builder';
 
 export const newsletterSignupSchema = z.object({
   email: z.string().email(),

--- a/packages/core/src/schemas/admin-packages.test.ts
+++ b/packages/core/src/schemas/admin-packages.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AdminPackageCreateSchema,
+  AdminPackageModifierCreateSchema,
+  AdminPackageModifierUpdateSchema,
+  AdminPackageUpdateSchema
+} from './admin-packages';
+
+describe('Admin package schemas', () => {
+  it('accepts valid package and modifier create payloads', () => {
+    const packageResult = AdminPackageCreateSchema.safeParse({
+      slug: 'signature-session',
+      name: 'Signature Session',
+      description: 'Our most popular package.',
+      basePriceCents: 25000,
+      status: 'ACTIVE'
+    });
+
+    const modifierResult = AdminPackageModifierCreateSchema.safeParse({
+      packageId: 'pkg_signature',
+      name: 'Extra Prints',
+      description: 'Set of 10 additional prints',
+      priceDeltaCents: 5000,
+      isRequired: false
+    });
+
+    expect(packageResult.success).toBe(true);
+    expect(modifierResult.success).toBe(true);
+  });
+
+  it('rejects invalid package create values', () => {
+    const badSlug = AdminPackageCreateSchema.safeParse({
+      slug: 'Bad Slug',
+      name: 'Signature Session'
+    });
+    const negativeBasePrice = AdminPackageCreateSchema.safeParse({
+      slug: 'signature-session',
+      name: 'Signature Session',
+      basePriceCents: -1
+    });
+
+    expect(badSlug.success).toBe(false);
+    expect(negativeBasePrice.success).toBe(false);
+  });
+
+  it('requires at least one field for package and modifier updates', () => {
+    const emptyPackageUpdate = AdminPackageUpdateSchema.safeParse({});
+    const emptyModifierUpdate = AdminPackageModifierUpdateSchema.safeParse({});
+
+    expect(emptyPackageUpdate.success).toBe(false);
+    expect(emptyModifierUpdate.success).toBe(false);
+  });
+});

--- a/packages/core/src/schemas/admin-packages.ts
+++ b/packages/core/src/schemas/admin-packages.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+export const PackageStatusSchema = z.enum(['DRAFT', 'ACTIVE', 'ARCHIVED']);
+
+export const AdminPackageCreateSchema = z.object({
+  slug: z
+    .string()
+    .min(2)
+    .regex(/^[a-z0-9-]+$/, 'Slug must be lowercase letters, numbers, and dashes.'),
+  name: z.string().min(2),
+  description: z.string().max(2000).optional(),
+  basePriceCents: z.number().int().nonnegative().optional(),
+  status: PackageStatusSchema.optional()
+});
+
+export const AdminPackageUpdateSchema = AdminPackageCreateSchema.partial().refine(
+  (payload) => Object.keys(payload).length > 0,
+  { message: 'At least one field is required for an update.' }
+);
+
+export const AdminPackageModifierCreateSchema = z.object({
+  packageId: z.string().min(1, 'Package is required.'),
+  name: z.string().min(2),
+  description: z.string().max(2000).optional(),
+  priceDeltaCents: z.number().int().optional(),
+  isRequired: z.boolean().optional()
+});
+
+export const AdminPackageModifierUpdateSchema = AdminPackageModifierCreateSchema.omit({
+  packageId: true
+})
+  .partial()
+  .refine((payload) => Object.keys(payload).length > 0, {
+    message: 'At least one field is required for an update.'
+  });
+
+export type PackageStatus = z.infer<typeof PackageStatusSchema>;
+export type AdminPackageCreateInput = z.infer<typeof AdminPackageCreateSchema>;
+export type AdminPackageUpdateInput = z.infer<typeof AdminPackageUpdateSchema>;
+export type AdminPackageModifierCreateInput = z.infer<typeof AdminPackageModifierCreateSchema>;
+export type AdminPackageModifierUpdateInput = z.infer<typeof AdminPackageModifierUpdateSchema>;

--- a/packages/core/src/schemas/booking-request.test.ts
+++ b/packages/core/src/schemas/booking-request.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { BookingRequestSubmissionPayloadSchema } from './booking-request';
+
+describe('BookingRequestSubmissionPayloadSchema', () => {
+  it('accepts a valid booking request submission payload', () => {
+    const result = BookingRequestSubmissionPayloadSchema.safeParse({
+      packageId: 'pkg_deluxe',
+      timeSlotId: 'slot_123',
+      guestCount: 8,
+      requestedAt: '2026-05-04T16:00:00.000Z',
+      selectedOptions: { backdrop: 'floral', delivery: true },
+      notes: 'Need wheelchair accessibility.'
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing package id', () => {
+    const result = BookingRequestSubmissionPayloadSchema.safeParse({
+      guestCount: 8
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid guest count boundary', () => {
+    const result = BookingRequestSubmissionPayloadSchema.safeParse({
+      packageId: 'pkg_deluxe',
+      guestCount: 0
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/core/src/schemas/booking-request.ts
+++ b/packages/core/src/schemas/booking-request.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const BookingRequestSubmissionPayloadSchema = z.object({
+  packageId: z.string().min(1, 'Package is required.'),
+  timeSlotId: z.string().min(1).optional(),
+  guestCount: z
+    .number()
+    .int('Guest count must be a whole number.')
+    .min(1, 'Guest count must be at least 1.')
+    .max(100, 'Guest count must be 100 or fewer.')
+    .optional(),
+  requestedAt: z.string().datetime('Requested date must be an ISO datetime string.').optional(),
+  selectedOptions: z.record(z.unknown()).optional(),
+  notes: z.string().max(2000).optional()
+});
+
+export type BookingRequestSubmissionPayload = z.infer<typeof BookingRequestSubmissionPayloadSchema>;

--- a/packages/core/src/schemas/package-builder.test.ts
+++ b/packages/core/src/schemas/package-builder.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { PackageBuilderRequestPayloadSchema } from './package-builder';
+
+describe('PackageBuilderRequestPayloadSchema', () => {
+  it('accepts a valid package builder payload', () => {
+    const result = PackageBuilderRequestPayloadSchema.safeParse({
+      packageId: 'pkg_basic',
+      guestCount: 6,
+      selectedModifierIds: ['mod_1', 'mod_2'],
+      requestedDate: '2026-04-20T15:00:00.000Z',
+      location: 'Austin, TX',
+      notes: 'Golden hour preferred.'
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects guest count outside supported boundaries', () => {
+    const tooLow = PackageBuilderRequestPayloadSchema.safeParse({
+      packageId: 'pkg_basic',
+      guestCount: 0,
+      requestedDate: '2026-04-20T15:00:00.000Z'
+    });
+    const tooHigh = PackageBuilderRequestPayloadSchema.safeParse({
+      packageId: 'pkg_basic',
+      guestCount: 101,
+      requestedDate: '2026-04-20T15:00:00.000Z'
+    });
+
+    expect(tooLow.success).toBe(false);
+    expect(tooHigh.success).toBe(false);
+  });
+
+  it('rejects invalid date formats', () => {
+    const result = PackageBuilderRequestPayloadSchema.safeParse({
+      packageId: 'pkg_basic',
+      guestCount: 4,
+      requestedDate: '04/20/2026'
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/core/src/schemas/package-builder.ts
+++ b/packages/core/src/schemas/package-builder.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const PackageBuilderRequestPayloadSchema = z.object({
+  packageId: z.string().min(1, 'Package is required.'),
+  guestCount: z
+    .number()
+    .int('Guest count must be a whole number.')
+    .min(1, 'Guest count must be at least 1.')
+    .max(100, 'Guest count must be 100 or fewer.'),
+  selectedModifierIds: z.array(z.string().min(1)).max(25).default([]),
+  requestedDate: z.string().datetime('Requested date must be an ISO datetime string.'),
+  location: z.string().min(2).max(200).optional(),
+  notes: z.string().max(2000).optional()
+});
+
+export type PackageBuilderRequestPayload = z.infer<typeof PackageBuilderRequestPayloadSchema>;


### PR DESCRIPTION
### Motivation
- Add server-side validation for package builder requests, booking submissions, and admin package/modifier create/update payloads to keep API inputs consistent and safe.
- Provide focused unit coverage for schema boundaries so future changes are less likely to regress input validation.

### Description
- Add new Zod schema modules: `packages/core/src/schemas/package-builder.ts`, `packages/core/src/schemas/booking-request.ts`, and `packages/core/src/schemas/admin-packages.ts` implementing field-level constraints and types.
- Add corresponding Vitest files: `packages/core/src/schemas/package-builder.test.ts`, `packages/core/src/schemas/booking-request.test.ts`, and `packages/core/src/schemas/admin-packages.test.ts` covering valid payloads and invalid boundary cases.
- Export the new schemas from `packages/core/src/schemas.ts` so they are available via the core package surface.

### Testing
- Ran `pnpm exec vitest run packages/core/src/schemas/*.test.ts --config vitest.config.ts` and all schema tests passed (5 files, 15 tests passed).
- Ran `pnpm --filter @repo/core typecheck` and `pnpm lint` and both succeeded for the changed package.
- Ran full monorepo `pnpm build`; it failed due to a pre-existing Prisma type export mismatch in `packages/db/src/index.ts` (missing `BookingRequest` export), which is unrelated to these schema changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ba1b344fc8329ac4da1dc5b22110c)