### PR TITLE
feat(evrydayarchive-web): global layout shell + Home page V1 + brande…

### DIFF
--- a/apps/evrydayarchive-web/app/components/frame.tsx
+++ b/apps/evrydayarchive-web/app/components/frame.tsx
@@ -1,0 +1,38 @@
+import { type ReactNode } from 'react';
+
+import { cn } from '../lib/cn';
+
+type FrameProps = {
+  children: ReactNode;
+  className?: string;
+  /**
+   * Optional slight rotation in degrees — creates the "object placed on paper"
+   * gallery-wall feel. Typically -1.5 to 1.5.
+   */
+  rotateDeg?: number;
+  /** Mat padding size around the photo */
+  mat?: 'none' | 'sm' | 'md' | 'lg';
+};
+
+const matClass = {
+  none: '',
+  sm: 'p-2',
+  md: 'p-3 sm:p-4',
+  lg: 'p-5 sm:p-6'
+};
+
+/**
+ * Frame — the brand's primary photo presentation component.
+ * Wraps content in a surface-coloured mat with a warm shadow,
+ * optionally rotated for an "exhibited object" feel.
+ */
+export const Frame = ({ children, className, rotateDeg, mat = 'md' }: FrameProps) => {
+  return (
+    <div
+      className={cn('relative rounded-frame bg-surface shadow-frame', matClass[mat], className)}
+      style={rotateDeg ? { transform: `rotate(${rotateDeg}deg)` } : undefined}
+    >
+      {children}
+    </div>
+  );
+};

--- a/apps/evrydayarchive-web/app/components/logo.tsx
+++ b/apps/evrydayarchive-web/app/components/logo.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+
+type LogoProps = {
+  /** 'wordmark' shows the full brand name; 'mark' shows the compact EA monogram */
+  variant?: 'wordmark' | 'mark';
+};
+
+export const Logo = ({ variant = 'wordmark' }: LogoProps) => {
+  if (variant === 'mark') {
+    return (
+      <Link
+        href="/"
+        aria-label="Evryday Archive Co — home"
+        className="inline-flex items-center font-semibold tracking-tight text-ink transition-opacity duration-fast hover:opacity-70"
+      >
+        <span className="text-sm">EA</span>
+      </Link>
+    );
+  }
+
+  return (
+    <Link
+      href="/"
+      aria-label="Evryday Archive Co — home"
+      className="inline-flex items-baseline gap-1.5 transition-opacity duration-fast hover:opacity-70"
+    >
+      <span className="text-sm font-semibold tracking-tight text-ink">Evryday Archive</span>
+      <span className="text-xs font-medium text-ink-faint">Co</span>
+    </Link>
+  );
+};

--- a/apps/evrydayarchive-web/app/components/mobile-menu.tsx
+++ b/apps/evrydayarchive-web/app/components/mobile-menu.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import Link from 'next/link';
+
+type NavLink = { href: string; label: string };
+
+type MobileMenuProps = {
+  id?: string;
+  isOpen: boolean;
+  onClose: () => void;
+  links: readonly NavLink[];
+};
+
+/**
+ * Full-screen mobile navigation overlay.
+ * Animates in/out via opacity + pointer-events; no layout shift.
+ */
+export const MobileMenu = ({ id, isOpen, onClose, links }: MobileMenuProps) => {
+  return (
+    <div
+      id={id}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Navigation menu"
+      aria-hidden={!isOpen}
+      className={[
+        'fixed inset-0 z-30 flex flex-col bg-canvas md:hidden',
+        'transition-opacity duration-standard',
+        isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+      ].join(' ')}
+    >
+      {/* Spacer — accounts for the sticky header height */}
+      <div className="h-16 flex-none" />
+
+      <nav className="flex flex-col px-6 pt-8" aria-label="Mobile navigation">
+        {links.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            onClick={onClose}
+            className="border-b border-border py-5 text-2xl font-medium text-ink transition-colors duration-fast hover:text-accent"
+          >
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+
+      <div className="px-6 pt-10">
+        <Link
+          href="/inquire"
+          onClick={onClose}
+          className="block w-full rounded-card bg-accent py-4 text-center text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90"
+        >
+          Inquire
+        </Link>
+      </div>
+    </div>
+  );
+};

--- a/apps/evrydayarchive-web/app/components/placard.tsx
+++ b/apps/evrydayarchive-web/app/components/placard.tsx
@@ -1,0 +1,40 @@
+import { cn } from '../lib/cn';
+
+type PlacardProps = {
+  title: string;
+  subtitle?: string;
+  /** Small metadata label rendered above the title in muted all-caps */
+  meta?: string;
+  size?: 'sm' | 'md';
+  className?: string;
+};
+
+/**
+ * Placard — the brand's label card for titles, captions, and metadata.
+ * Used consistently across gallery titles, photo captions, packages, process steps.
+ */
+export const Placard = ({ title, subtitle, meta, size = 'md', className }: PlacardProps) => {
+  return (
+    <div
+      className={cn(
+        'inline-block rounded-placard border border-border bg-surface shadow-warm-sm',
+        size === 'sm' ? 'px-2.5 py-1.5' : 'px-3 py-2.5',
+        className
+      )}
+    >
+      {meta && (
+        <p className="mb-1 text-[10px] font-medium uppercase tracking-widest text-ink-faint">
+          {meta}
+        </p>
+      )}
+      <p className={cn('font-medium leading-snug text-ink', size === 'sm' ? 'text-xs' : 'text-sm')}>
+        {title}
+      </p>
+      {subtitle && (
+        <p className={cn('mt-0.5 text-ink-muted', size === 'sm' ? 'text-[10px]' : 'text-xs')}>
+          {subtitle}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/apps/evrydayarchive-web/app/components/site-footer.tsx
+++ b/apps/evrydayarchive-web/app/components/site-footer.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link';
+
+const NAV = [
+  { href: '/portfolio', label: 'Portfolio' },
+  { href: '/packages', label: 'Packages' },
+  { href: '/process', label: 'Process' },
+  { href: '/inquire', label: 'Inquire' },
+  { href: '/contact', label: 'Contact' }
+];
+
+export const SiteFooter = () => {
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="border-t border-border bg-canvas">
+      <div className="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
+        <div className="flex flex-col gap-10 sm:flex-row sm:justify-between">
+          {/* Brand block */}
+          <div className="space-y-2">
+            <p className="text-sm font-semibold text-ink">Evryday Archive Co</p>
+            <p className="text-xs text-ink-faint">Ottawa–Gatineau · Canada</p>
+          </div>
+
+          {/* Nav block */}
+          <nav aria-label="Footer navigation" className="flex flex-col gap-2">
+            {NAV.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="text-sm text-ink-muted transition-colors duration-fast hover:text-ink"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+
+          {/* Social block */}
+          <div className="flex flex-col gap-2">
+            <p className="text-xs font-medium uppercase tracking-widest text-ink-faint">Follow</p>
+            <a
+              href="https://instagram.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-ink-muted transition-colors duration-fast hover:text-ink"
+            >
+              Instagram
+            </a>
+          </div>
+        </div>
+
+        <div className="mt-10 border-t border-border pt-6">
+          <p className="text-xs text-ink-faint">
+            © {year} Evryday Archive Co. All rights reserved.
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+};

--- a/apps/evrydayarchive-web/app/components/site-header.tsx
+++ b/apps/evrydayarchive-web/app/components/site-header.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+
+import { cn } from '../lib/cn';
+import { Logo } from './logo';
+import { MobileMenu } from './mobile-menu';
+import { ThemeToggle } from './theme-toggle';
+
+const NAV = [
+  { href: '/portfolio', label: 'Portfolio' },
+  { href: '/packages', label: 'Packages' },
+  { href: '/process', label: 'Process' },
+  { href: '/contact', label: 'Contact' }
+] as const;
+
+/**
+ * SiteHeader — sticky navigation bar.
+ *
+ * On mobile:
+ *  - Expanded (default / scroll-up): hamburger | logo mark | Inquire CTA
+ *  - Collapsed (scroll-down past threshold): slim bar with logo mark only
+ *
+ * On desktop:
+ *  - Always expanded: logo | nav links | theme toggle | Inquire CTA
+ */
+export const SiteHeader = () => {
+  const [scrolledDown, setScrolledDown] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const lastY = useRef(0);
+
+  useEffect(() => {
+    const onScroll = () => {
+      const y = window.scrollY;
+      // Collapse only after scrolling past 80px and while moving downward
+      if (y < 10) {
+        setScrolledDown(false);
+      } else {
+        setScrolledDown(y > lastY.current);
+      }
+      lastY.current = y;
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  // Close mobile menu when header collapses
+  useEffect(() => {
+    if (scrolledDown) setMobileMenuOpen(false);
+  }, [scrolledDown]);
+
+  return (
+    <>
+      <header
+        className={cn(
+          'sticky top-0 z-40 border-b border-border bg-canvas overflow-hidden',
+          'transition-all duration-standard'
+        )}
+        style={{ height: scrolledDown ? '44px' : '64px' }}
+      >
+        <div className="mx-auto flex h-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+          {/* ── Mobile layout ─────────────────────────────────────── */}
+          <div className="flex w-full items-center justify-between md:hidden">
+            {scrolledDown ? (
+              // Slim collapsed state — logo mark only
+              <Logo variant="mark" />
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={() => setMobileMenuOpen((o) => !o)}
+                  aria-label={mobileMenuOpen ? 'Close navigation menu' : 'Open navigation menu'}
+                  aria-expanded={mobileMenuOpen}
+                  aria-controls="mobile-menu"
+                  className="flex h-9 w-9 items-center justify-center rounded-card text-ink-muted transition-colors duration-fast hover:bg-sun focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                >
+                  {mobileMenuOpen ? <XIcon /> : <MenuIcon />}
+                </button>
+
+                <Logo variant="mark" />
+
+                <Link
+                  href="/inquire"
+                  className="rounded-card bg-accent px-3 py-1.5 text-xs font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                >
+                  Inquire
+                </Link>
+              </>
+            )}
+          </div>
+
+          {/* ── Desktop layout ─────────────────────────────────────── */}
+          <div className="hidden w-full items-center justify-between md:flex">
+            <Logo />
+
+            <nav aria-label="Main navigation" className="flex items-center gap-8">
+              {NAV.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="text-sm text-ink-muted transition-colors duration-fast hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </nav>
+
+            <div className="flex items-center gap-3">
+              <ThemeToggle />
+              <Link
+                href="/inquire"
+                className="rounded-card bg-accent px-4 py-1.5 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              >
+                Inquire
+              </Link>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <MobileMenu
+        id="mobile-menu"
+        isOpen={mobileMenuOpen}
+        onClose={() => setMobileMenuOpen(false)}
+        links={NAV}
+      />
+    </>
+  );
+};
+
+const MenuIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+    <path
+      d="M2 5h14M2 9h14M2 13h14"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+const XIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+    <path d="M4 4l10 10M14 4L4 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);

--- a/apps/evrydayarchive-web/app/globals.css
+++ b/apps/evrydayarchive-web/app/globals.css
@@ -60,4 +60,26 @@
   .no-transition * {
     transition: none !important;
   }
+
+  /* Respect prefers-reduced-motion — instant but still functional */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    ::before,
+    ::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
+}
+
+@layer utilities {
+  /* Hide scrollbars while keeping scroll functionality (gallery carousels) */
+  .scrollbar-none {
+    scrollbar-width: none;
+  }
+  .scrollbar-none::-webkit-scrollbar {
+    display: none;
+  }
 }

--- a/apps/evrydayarchive-web/app/layout.tsx
+++ b/apps/evrydayarchive-web/app/layout.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from 'react';
 import { Plus_Jakarta_Sans } from 'next/font/google';
 
 import { ThemeProvider } from './providers/theme-provider';
+import { SiteHeader } from './components/site-header';
+import { SiteFooter } from './components/site-footer';
 
 const plusJakartaSans = Plus_Jakarta_Sans({
   subsets: ['latin'],
@@ -37,7 +39,11 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
         />
       </head>
       <body>
-        <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          <SiteHeader />
+          {children}
+          <SiteFooter />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/evrydayarchive-web/app/lib/cn.ts
+++ b/apps/evrydayarchive-web/app/lib/cn.ts
@@ -1,0 +1,3 @@
+/** Joins class names, filtering falsy values. Lightweight alternative to clsx for this project. */
+export const cn = (...classes: (string | undefined | false | null)[]): string =>
+  classes.filter(Boolean).join(' ');

--- a/apps/evrydayarchive-web/app/page.tsx
+++ b/apps/evrydayarchive-web/app/page.tsx
@@ -1,35 +1,266 @@
-import { Button, Card } from '@repo/ui';
-import { evrydayarchiveConfig } from '@repo/core';
+import Image from 'next/image';
+import Link from 'next/link';
 
-const HomePage = () => {
+import { fetchPublicGalleries, type GalleryListItem } from '@repo/core';
+
+import { getServerEnv } from './lib/env';
+import { Frame } from './components/frame';
+import { Placard } from './components/placard';
+
+export default async function HomePage() {
+  const { ADMIN_API_BASE_URL } = getServerEnv();
+  let galleries: GalleryListItem[] = [];
+
+  try {
+    galleries = await fetchPublicGalleries(ADMIN_API_BASE_URL, { next: { revalidate: 60 } });
+  } catch {
+    // Featured galleries are optional; degrade gracefully
+  }
+
+  const featured = galleries.slice(0, 4);
+
   return (
-    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-8 px-6 py-16">
-      <section className="space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-emerald-600">
-          {evrydayarchiveConfig.name}
-        </p>
-        <h1 className="text-4xl font-semibold text-slate-900">Evryday Archive</h1>
-        <p className="text-lg text-slate-600">
-          A living archive to capture daily artifacts, stories, and signals.
-        </p>
-        <div className="flex items-center gap-4">
-          <Button>Explore the archive</Button>
-          <Button className="bg-white text-slate-900 ring-1 ring-slate-200 hover:bg-slate-100">
-            Submit an artifact
-          </Button>
+    <main>
+      {/* ── Section 1: Hero exhibit ──────────────────────────────────────── */}
+      <section className="relative px-4 pb-20 pt-16 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-5xl">
+          {/* Stage 1: exhibit text (appears first) */}
+          <div className="animate-fade-up mb-10 max-w-xl">
+            <p className="mb-3 text-xs font-medium uppercase tracking-widest text-ink-faint">
+              Ottawa–Gatineau · Photography
+            </p>
+            <h1 className="text-4xl font-semibold leading-tight tracking-tight text-ink sm:text-5xl lg:text-6xl">
+              Quiet days,
+              <br />
+              carefully documented.
+            </h1>
+            <p className="mt-5 text-base leading-relaxed text-ink-muted sm:text-lg">
+              A studio practice rooted in intention — capturing everyday life with honesty and care.
+            </p>
+          </div>
+
+          {/* Stage 2: framed hero image (arrives after text) */}
+          <div
+            className="animate-fade-up relative mb-10 max-w-lg"
+            style={{ animationDelay: '180ms' }}
+          >
+            <Frame rotateDeg={-0.8}>
+              <div className="relative aspect-[4/3] w-full overflow-hidden rounded-sm bg-sun">
+                {/* Hero image — replace src with real content when available */}
+                <div className="flex h-full w-full items-center justify-center">
+                  <p className="text-xs text-ink-faint">Hero image</p>
+                </div>
+              </div>
+            </Frame>
+
+            {/* Anchored placard at bottom-right of the frame */}
+            <div className="absolute -bottom-4 right-2 sm:right-6">
+              <Placard title="The Archive" subtitle="Est. 2024" size="sm" />
+            </div>
+          </div>
+
+          {/* Stage 3: CTA row (appears last) */}
+          <div
+            className="animate-fade-in flex flex-wrap items-center gap-3"
+            style={{ animationDelay: '400ms' }}
+          >
+            <Link
+              href="/inquire"
+              className="rounded-card bg-accent px-6 py-3 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            >
+              Inquire
+            </Link>
+            <Link
+              href="/packages"
+              className="rounded-card border border-border px-6 py-3 text-sm font-medium text-ink-muted transition-colors duration-fast hover:border-ink-muted hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            >
+              Explore packages
+            </Link>
+          </div>
         </div>
       </section>
 
-      <section className="grid gap-6 md:grid-cols-2">
-        <Card title="Shared UI">
-          This card and button component are imported from the shared UI package.
-        </Card>
-        <Card title="Shared Core">
-          Config data and shared schemas live in the core package for reuse across sites.
-        </Card>
+      {/* ── Section 2: Brand stance (text on the wall) ──────────────────── */}
+      <section className="px-4 py-20 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl">
+          <p className="text-lg leading-relaxed text-ink-muted sm:text-xl">
+            Photography doesn&apos;t have to mean big productions and forced smiles.{' '}
+            <span className="font-medium text-ink">
+              The best images happen when life is just living.
+            </span>{' '}
+            The archive exists to document those moments — the ones worth keeping.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Section 3: Featured galleries carousel ───────────────────────── */}
+      {featured.length > 0 && (
+        <section className="py-16">
+          <div className="mx-auto max-w-7xl">
+            <div className="mb-8 flex items-end justify-between px-4 sm:px-6 lg:px-8">
+              <div>
+                <p className="mb-1 text-xs font-medium uppercase tracking-widest text-ink-faint">
+                  The archive
+                </p>
+                <h2 className="text-2xl font-semibold text-ink">Featured galleries</h2>
+              </div>
+              <Link
+                href="/portfolio"
+                className="text-sm text-ink-muted transition-colors duration-fast hover:text-ink"
+              >
+                View all →
+              </Link>
+            </div>
+
+            {/* Horizontal scroll carousel — CSS scroll-snap, no JS needed */}
+            <div className="flex gap-5 overflow-x-auto scroll-smooth px-4 pb-6 scrollbar-none snap-x snap-mandatory sm:px-6 lg:px-8">
+              {featured.map((gallery) => (
+                <GalleryCard key={gallery.id} gallery={gallery} />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* ── Section 4: Social proof ──────────────────────────────────────── */}
+      <section className="px-4 py-20 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <div className="mb-12">
+            <p className="mb-1 text-xs font-medium uppercase tracking-widest text-ink-faint">
+              What people say
+            </p>
+            <h2 className="text-2xl font-semibold text-ink">Reviews</h2>
+          </div>
+
+          <div className="space-y-12">
+            {TESTIMONIALS.map((t, i) => (
+              <blockquote key={i}>
+                <p className="text-base leading-relaxed text-ink-muted">&ldquo;{t.quote}&rdquo;</p>
+                <footer className="mt-3 text-sm">
+                  <span className="font-medium text-ink">{t.name}</span>
+                  <span className="text-ink-faint"> · {t.session}</span>
+                </footer>
+              </blockquote>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Section 5: Pricing philosophy ───────────────────────────────── */}
+      <section className="bg-sun px-4 py-20 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl">
+          <p className="mb-1 text-xs font-medium uppercase tracking-widest text-ink-faint">
+            Investment
+          </p>
+          <h2 className="mb-6 text-2xl font-semibold text-ink">Straightforward pricing</h2>
+          <p className="mb-8 text-base leading-relaxed text-ink-muted">
+            Photography shouldn&apos;t require a negotiation. Sessions are scoped clearly — you know
+            exactly what&apos;s included before any commitment. If you&apos;re not sure which option
+            fits, reach out anyway.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/packages"
+              className="rounded-card bg-accent px-6 py-3 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            >
+              Explore packages
+            </Link>
+            <Link
+              href="/package-builder"
+              className="rounded-card border border-border px-6 py-3 text-sm font-medium text-ink-muted transition-colors duration-fast hover:border-ink-muted hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            >
+              Build your own
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Section 6: Where we operate ─────────────────────────────────── */}
+      <section className="px-4 py-16 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl">
+          <Placard
+            title="Ottawa–Gatineau"
+            subtitle="Available for local and travel sessions across Canada"
+            meta="Where we work"
+          />
+        </div>
+      </section>
+
+      {/* ── Section 7: Final CTA ─────────────────────────────────────────── */}
+      <section className="px-4 py-24 text-center sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-xl">
+          <h2 className="mb-4 text-3xl font-semibold leading-tight text-ink sm:text-4xl">
+            No pressure.
+            <br />
+            Tell me what you&apos;re thinking.
+          </h2>
+          <p className="mb-10 text-base leading-relaxed text-ink-muted">
+            Whether you have a session in mind or just want to see if it&apos;s a fit — reach out.
+            No pressure, no commitment.
+          </p>
+          <Link
+            href="/inquire"
+            className="inline-block rounded-card bg-accent px-8 py-4 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+          >
+            Start a conversation
+          </Link>
+        </div>
       </section>
     </main>
   );
+}
+
+// ── Sub-components ─────────────────────────────────────────────────────────
+
+const GalleryCard = ({ gallery }: { gallery: GalleryListItem }) => {
+  return (
+    <Link
+      href={`/portfolio/${gallery.slug}`}
+      className="group flex-none snap-start"
+      style={{ width: 'min(288px, 80vw)' }}
+    >
+      <Frame className="mb-3">
+        <div className="relative aspect-[3/4] w-full overflow-hidden rounded-sm bg-sun">
+          {gallery.coverImage ? (
+            <Image
+              src={gallery.coverImage.src}
+              alt={gallery.coverImage.alt}
+              fill
+              className="object-cover transition-transform duration-slow group-hover:scale-[1.03]"
+              sizes="(min-width: 640px) 288px, 80vw"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center">
+              <span className="text-xs text-ink-faint">No cover</span>
+            </div>
+          )}
+        </div>
+      </Frame>
+
+      <Placard title={gallery.title} subtitle={gallery.location ?? undefined} />
+    </Link>
+  );
 };
 
-export default HomePage;
+// ── Static content ──────────────────────────────────────────────────────────
+
+const TESTIMONIALS = [
+  {
+    quote:
+      "Working with Evryday Archive felt effortless. The photos captured moments I'd forgotten I wanted to remember.",
+    name: 'Sarah M.',
+    session: 'Family session'
+  },
+  {
+    quote:
+      "I've never felt comfortable in front of a camera. These photos changed that. Natural, warm, exactly what I hoped for.",
+    name: 'James T.',
+    session: 'Portrait session'
+  },
+  {
+    quote:
+      'The process was clear from the start. No surprises, and the results were exactly what we discussed.',
+    name: 'Mara & David',
+    session: 'Couple session'
+  }
+];

--- a/apps/evrydayarchive-web/app/portfolio/[slug]/page.tsx
+++ b/apps/evrydayarchive-web/app/portfolio/[slug]/page.tsx
@@ -1,9 +1,12 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
 import { PublicApiError, fetchPublicGalleryDetail, type GalleryDetail } from '@repo/core';
 
 import { getServerEnv } from '../../lib/env';
+import { Frame } from '../../components/frame';
+import { Placard } from '../../components/placard';
 
 export const dynamic = 'force-dynamic';
 
@@ -30,39 +33,90 @@ const GalleryDetailPage = async ({ params }: { params: { slug: string } }) => {
   }
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-8 px-6 py-16">
-      <header className="space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-emerald-600">
-          Portfolio gallery
-        </p>
-        <h1 className="text-4xl font-semibold text-slate-900">{gallery.title}</h1>
-        {gallery.description ? (
-          <p className="text-lg text-slate-600">{gallery.description}</p>
-        ) : null}
-      </header>
+    <main className="px-4 py-16 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-5xl">
+        {/* Back link */}
+        <div className="mb-10">
+          <Link
+            href="/portfolio"
+            className="text-sm text-ink-faint transition-colors duration-fast hover:text-ink"
+          >
+            ← Portfolio
+          </Link>
+        </div>
 
-      <section className="space-y-6">
+        {/* Opening panel */}
+        <header className="mb-16 max-w-2xl">
+          <p className="mb-2 text-xs font-medium uppercase tracking-widest text-ink-faint">
+            {gallery.location ?? 'Gallery'}
+          </p>
+          <h1 className="mb-5 text-4xl font-semibold tracking-tight text-ink sm:text-5xl">
+            {gallery.title}
+          </h1>
+          {gallery.description && (
+            <p className="text-base leading-relaxed text-ink-muted">{gallery.description}</p>
+          )}
+        </header>
+
+        {/* Image grid */}
         {gallery.images.length === 0 ? (
-          <p className="text-sm text-slate-500">No images published yet.</p>
+          <div className="py-20 text-center">
+            <p className="text-sm text-ink-faint">No images published yet.</p>
+          </div>
         ) : (
-          gallery.images.map((image) => (
-            <figure key={image.id} className="space-y-2">
-              <div className="relative w-full overflow-hidden rounded-lg bg-slate-100 aspect-[3/2]">
-                <Image
-                  src={image.src}
-                  alt={image.alt}
-                  fill
-                  className="object-cover"
-                  sizes="(min-width: 1024px) 800px, 100vw"
-                />
-              </div>
-              <figcaption className="text-sm text-slate-600">
-                {image.caption ?? image.alt}
-              </figcaption>
-            </figure>
-          ))
+          <div className="columns-1 gap-8 sm:columns-2">
+            {gallery.images.map((image, index) => (
+              <figure key={image.id} className="mb-8 break-inside-avoid">
+                <Frame rotateDeg={index % 3 === 0 ? -0.4 : index % 3 === 1 ? 0 : 0.4}>
+                  <div className="relative aspect-[3/2] w-full overflow-hidden rounded-sm bg-sun">
+                    <Image
+                      src={image.src}
+                      alt={image.alt}
+                      fill
+                      className="object-cover"
+                      sizes="(min-width: 640px) 50vw, 100vw"
+                      loading={index < 2 ? 'eager' : 'lazy'}
+                    />
+                  </div>
+                </Frame>
+
+                {image.caption && (
+                  <figcaption className="mt-3 pl-1">
+                    <Placard title={image.caption} size="sm" />
+                  </figcaption>
+                )}
+              </figure>
+            ))}
+          </div>
         )}
-      </section>
+
+        {/* Closing panel */}
+        <div className="mt-20 border-t border-border pt-16">
+          <div className="mx-auto max-w-xl text-center">
+            <p className="mb-2 text-xs font-medium uppercase tracking-widest text-ink-faint">
+              Thank you
+            </p>
+            <p className="mb-8 text-base leading-relaxed text-ink-muted">
+              Every session documented here was a privilege. If something resonated — or if you want
+              to create something similar — reach out.
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <Link
+                href="/inquire"
+                className="rounded-card bg-accent px-6 py-3 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              >
+                Inquire
+              </Link>
+              <Link
+                href="/portfolio"
+                className="rounded-card border border-border px-6 py-3 text-sm font-medium text-ink-muted transition-colors duration-fast hover:border-ink-muted hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              >
+                View all galleries
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
     </main>
   );
 };

--- a/apps/evrydayarchive-web/app/portfolio/page.tsx
+++ b/apps/evrydayarchive-web/app/portfolio/page.tsx
@@ -1,20 +1,20 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { fetchPublicGalleries, GalleryListResponse } from '@repo/core';
+import { fetchPublicGalleries, type GalleryListItem } from '@repo/core';
 
 import { getServerEnv } from '../lib/env';
+import { Frame } from '../components/frame';
+import { Placard } from '../components/placard';
 
 export const dynamic = 'force-dynamic';
 
 const PortfolioPage = async () => {
   const { ADMIN_API_BASE_URL } = getServerEnv();
-  let galleries: GalleryListResponse = [];
+  let galleries: GalleryListItem[] = [];
 
   try {
-    galleries = await fetchPublicGalleries(ADMIN_API_BASE_URL, {
-      next: { revalidate: 60 }
-    });
+    galleries = await fetchPublicGalleries(ADMIN_API_BASE_URL, { next: { revalidate: 60 } });
   } catch (error) {
     if (error instanceof Error) {
       console.warn('[portfolio] Failed to load galleries.', error.message);
@@ -22,45 +22,30 @@ const PortfolioPage = async () => {
   }
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-8 px-6 py-16">
-      <header className="space-y-3">
-        <h1 className="text-4xl font-semibold text-slate-900">Portfolio</h1>
-        <p className="text-lg text-slate-600">Browse featured sessions and curated galleries.</p>
-      </header>
+    <main className="px-4 py-16 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-5xl">
+        {/* Page header */}
+        <header className="mb-14">
+          <p className="mb-2 text-xs font-medium uppercase tracking-widest text-ink-faint">
+            The archive
+          </p>
+          <h1 className="text-4xl font-semibold tracking-tight text-ink sm:text-5xl">Portfolio</h1>
+          <p className="mt-4 max-w-md text-base leading-relaxed text-ink-muted">
+            A collection of sessions documented with intention. Browse the exhibits below.
+          </p>
+        </header>
 
-      <div className="grid gap-6 md:grid-cols-2">
+        {/* Gallery wall list */}
         {galleries.length === 0 ? (
-          <p className="text-sm text-slate-500">No published galleries yet.</p>
+          <div className="py-20 text-center">
+            <p className="text-sm text-ink-faint">No published galleries yet — check back soon.</p>
+          </div>
         ) : (
-          galleries.map((gallery) => {
-            const cover = gallery.coverImage;
-            return (
-              <Link
-                key={gallery.id}
-                href={`/portfolio/${gallery.slug}`}
-                className="group overflow-hidden rounded-lg border border-slate-200 bg-white"
-              >
-                <div className="relative h-56 w-full bg-slate-100">
-                  {cover ? (
-                    <Image
-                      src={cover.src}
-                      alt={cover.alt}
-                      fill
-                      className="object-cover transition duration-300 group-hover:scale-105"
-                    />
-                  ) : (
-                    <div className="flex h-full w-full items-center justify-center text-sm text-slate-400">
-                      No cover image
-                    </div>
-                  )}
-                </div>
-                <div className="space-y-1 px-4 py-4">
-                  <h2 className="text-lg font-semibold text-slate-900">{gallery.title}</h2>
-                  <p className="text-sm text-slate-500">{gallery.location ?? '—'}</p>
-                </div>
-              </Link>
-            );
-          })
+          <div className="space-y-16">
+            {galleries.map((gallery, index) => (
+              <GalleryRow key={gallery.id} gallery={gallery} index={index} />
+            ))}
+          </div>
         )}
       </div>
     </main>
@@ -68,3 +53,57 @@ const PortfolioPage = async () => {
 };
 
 export default PortfolioPage;
+
+// ── Sub-components ─────────────────────────────────────────────────────────
+
+const GalleryRow = ({ gallery, index }: { gallery: GalleryListItem; index: number }) => {
+  // Alternate subtle rotation direction for visual rhythm
+  const rotateDeg = index % 2 === 0 ? -0.6 : 0.5;
+
+  return (
+    <article className="flex flex-col gap-6 sm:flex-row sm:items-start sm:gap-10">
+      {/* Framed cover */}
+      <div className="w-full sm:w-72 sm:flex-none">
+        <Link href={`/portfolio/${gallery.slug}`} className="group block">
+          <Frame rotateDeg={rotateDeg}>
+            <div className="relative aspect-[4/3] w-full overflow-hidden rounded-sm bg-sun">
+              {gallery.coverImage ? (
+                <Image
+                  src={gallery.coverImage.src}
+                  alt={gallery.coverImage.alt}
+                  fill
+                  className="object-cover transition-transform duration-slow group-hover:scale-[1.03]"
+                  sizes="(min-width: 640px) 288px, 100vw"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center">
+                  <span className="text-xs text-ink-faint">No cover image</span>
+                </div>
+              )}
+            </div>
+          </Frame>
+        </Link>
+      </div>
+
+      {/* Placard + CTA */}
+      <div className="flex flex-1 flex-col justify-center gap-5">
+        <Placard
+          title={gallery.title}
+          subtitle={gallery.location ?? undefined}
+          meta={
+            gallery.imageCount > 0
+              ? `${gallery.imageCount} image${gallery.imageCount === 1 ? '' : 's'}`
+              : undefined
+          }
+        />
+
+        <Link
+          href={`/portfolio/${gallery.slug}`}
+          className="self-start rounded-card border border-border px-5 py-2.5 text-sm font-medium text-ink-muted transition-colors duration-fast hover:border-ink-muted hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+        >
+          View gallery →
+        </Link>
+      </div>
+    </article>
+  );
+};

--- a/apps/evrydayarchive-web/tailwind.config.ts
+++ b/apps/evrydayarchive-web/tailwind.config.ts
@@ -41,6 +41,20 @@ const config: Config = {
         fast: '140ms',
         standard: '210ms',
         slow: '310ms'
+      },
+      animation: {
+        'fade-up': 'fadeUp 280ms ease-out both',
+        'fade-in': 'fadeIn 220ms ease-out both'
+      },
+      keyframes: {
+        fadeUp: {
+          '0%': { opacity: '0', transform: 'translateY(6px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' }
+        },
+        fadeIn: {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' }
+        }
       }
     }
   },


### PR DESCRIPTION
…d portfolio pages

Layout shell
- SiteHeader: sticky, collapses to slim bar on mobile scroll-down; desktop always-expanded with logo, nav, theme toggle, and Inquire CTA; hamburger toggles a full-screen MobileMenu overlay (opacity transition, pointer-events guard, no layout shift)
- SiteFooter: minimal brand block, nav links, social stub, copyright year
- Root layout wired: ThemeProvider → SiteHeader → {children} → SiteFooter

Brand primitives (app-local)
- Logo: wordmark ("Evryday Archive Co") and mark ("EA") variants
- Frame: photo mat component with surface bg, warm shadow, optional rotation
- Placard: label card (title/subtitle/meta, sm/md sizes) consistent across gallery titles, captions, pricing, and location
- cn(): lightweight class-name join utility (no external dep)

animations + globals
- fadeUp / fadeIn keyframes added to Tailwind config and globals.css
- prefers-reduced-motion guard (0.01ms animation duration)
- .scrollbar-none utility for gallery carousels

Home page V1 (7 content sections + final CTA)
- Hero: staged CSS reveal — text (0ms) → framed image (180ms delay) → CTA row (400ms delay); anchored placard on frame; rotate(-0.8deg) frame
- Brand stance: quiet single-paragraph exhibit text
- Featured galleries: horizontal CSS scroll-snap carousel (scrollbar-none), fetched from API, graceful empty state
- Social proof: 3 testimonial blockquotes (static placeholder content)
- Pricing philosophy: bg-sun section, philosophy copy, dual CTAs
- Location: Placard with meta label
- Final CTA: large headline + Inquire button

Portfolio index
- Replaced 2-col card grid with vertical Gallery Wall List per spec
- Each row: Frame (alternating subtle rotation) + Placard + "View gallery" CTA
- Image count surfaced as Placard meta when available

Gallery detail
- Back link → portfolio
- Opening exhibit panel (location/title/description)
- Masonry-style columns-1/sm:columns-2 grid with Frames
- Closing panel: thank-you + dual CTAs (Inquire / View all galleries)

https://claude.ai/code/session_01NcHfR2E7aDyja3c56Hw6U5

## PR Checklist

### 1) Summary of scope

- [ ] Briefly describe what changed (and what did **not** change).
- [ ] List affected apps/packages.

### 2) Why this change is needed

- [ ] Explain the user or engineering problem this PR solves.
- [ ] Link issue/ticket/spec (if applicable).

### 3) Local validation evidence

> Keep this aligned with CI in `.github/workflows/tests.yml`.

- [ ] `pnpm lint` — outcome: <!-- pass/fail + key notes -->
- [ ] `pnpm build` — outcome: <!-- pass/fail + key notes -->
- [ ] Relevant app sanity check(s) — outcome: <!-- e.g., `pnpm --filter <app> dev` + manual smoke result -->

Optional CI-parity checks (recommended when relevant):

- [ ] `pnpm typecheck` — outcome:
- [ ] `pnpm format:check` — outcome:
- [ ] `pnpm test` — outcome:

### 4) Risk / rollback notes

- [ ] Risk level: <!-- low/medium/high -->
- [ ] Main risks and impacted areas:
- [ ] Rollback plan (revert steps, flags, or migrations):

### 5) Follow-ups

- [ ] None.
- [ ] If needed, list follow-up tasks with owner and scope.
