### PR TITLE
feat(admin): packages management UI

### DIFF
--- a/apps/admin/app/galleries/page.tsx
+++ b/apps/admin/app/galleries/page.tsx
@@ -19,7 +19,10 @@ const GalleriesPage = async () => {
     <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-6 px-6 py-16">
       <header className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-semibold text-slate-900">Portfolio Galleries</h1>
+          <Link href="/packages" className="text-sm text-slate-500 hover:text-slate-700">
+            Packages →
+          </Link>
+          <h1 className="mt-3 text-3xl font-semibold text-slate-900">Portfolio Galleries</h1>
           <p className="text-sm text-slate-500">Manage the published gallery lineup.</p>
         </div>
         <Link

--- a/apps/admin/app/packages/[id]/page.tsx
+++ b/apps/admin/app/packages/[id]/page.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { prisma } from '@repo/db';
+
+import PackageEditor from '../components/PackageEditor';
+
+export const dynamic = 'force-dynamic';
+
+const PackageDetailPage = async ({ params }: { params: { id: string } }) => {
+  const pkg = await prisma.package.findUnique({
+    where: { id: params.id },
+    include: {
+      modifiers: {
+        orderBy: { createdAt: 'asc' }
+      }
+    }
+  });
+
+  if (!pkg) {
+    notFound();
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-6 px-6 py-16">
+      <header>
+        <Link href="/packages" className="text-sm text-slate-500 hover:text-slate-700">
+          ← Back to packages
+        </Link>
+        <h1 className="mt-3 text-3xl font-semibold text-slate-900">{pkg.name}</h1>
+        <p className="text-sm text-slate-500">Edit package details and modifiers.</p>
+      </header>
+      <PackageEditor pkg={pkg} />
+    </main>
+  );
+};
+
+export default PackageDetailPage;

--- a/apps/admin/app/packages/components/NewPackageForm.tsx
+++ b/apps/admin/app/packages/components/NewPackageForm.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+const initialState = {
+  name: '',
+  slug: '',
+  description: '',
+  basePriceDollars: ''
+};
+
+const NewPackageForm = () => {
+  const router = useRouter();
+  const [formState, setFormState] = useState(initialState);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleChange =
+    (field: keyof typeof initialState) =>
+    (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setFormState((prev) => ({ ...prev, [field]: event.target.value }));
+    };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    const basePriceCents = formState.basePriceDollars
+      ? Math.round(parseFloat(formState.basePriceDollars) * 100)
+      : undefined;
+
+    const response = await fetch('/api/packages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: formState.name,
+        slug: formState.slug,
+        description: formState.description || undefined,
+        basePriceCents
+      })
+    });
+
+    const payload = await response.json();
+
+    if (!payload.ok) {
+      setError(payload.error?.message ?? 'Unable to create package.');
+      setIsSubmitting(false);
+      return;
+    }
+
+    router.push(`/packages/${payload.data.id}`);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+        Name
+        <input
+          value={formState.name}
+          onChange={handleChange('name')}
+          className="rounded-md border border-slate-200 px-3 py-2 text-sm"
+          required
+        />
+      </label>
+      <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+        Slug
+        <input
+          value={formState.slug}
+          onChange={handleChange('slug')}
+          placeholder="e.g. family-session"
+          className="rounded-md border border-slate-200 px-3 py-2 text-sm"
+          required
+        />
+      </label>
+      <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+        Description
+        <textarea
+          value={formState.description}
+          onChange={handleChange('description')}
+          className="rounded-md border border-slate-200 px-3 py-2 text-sm"
+          rows={3}
+        />
+      </label>
+      <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+        Base price ($)
+        <input
+          value={formState.basePriceDollars}
+          onChange={handleChange('basePriceDollars')}
+          placeholder="e.g. 350"
+          className="rounded-md border border-slate-200 px-3 py-2 text-sm"
+          inputMode="decimal"
+        />
+      </label>
+      {error ? (
+        <p className="text-sm text-rose-600" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:bg-indigo-300"
+      >
+        {isSubmitting ? 'Creating...' : 'Create package'}
+      </button>
+    </form>
+  );
+};
+
+export default NewPackageForm;

--- a/apps/admin/app/packages/components/PackageEditor.tsx
+++ b/apps/admin/app/packages/components/PackageEditor.tsx
@@ -1,0 +1,356 @@
+'use client';
+
+import { useState } from 'react';
+
+const statusOptions = ['DRAFT', 'ACTIVE', 'ARCHIVED'] as const;
+type PackageStatus = (typeof statusOptions)[number];
+
+type PackageModifier = {
+  id: string;
+  name: string;
+  description: string | null;
+  priceDeltaCents: number | null;
+  isRequired: boolean;
+};
+
+type PackageData = {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  basePriceCents: number | null;
+  status: PackageStatus;
+  modifiers: PackageModifier[];
+};
+
+type PackageEditorProps = {
+  pkg: PackageData;
+};
+
+const centsToDisplayDollars = (cents: number | null): string => {
+  if (cents == null) return '';
+  return (cents / 100).toFixed(2);
+};
+
+const PackageEditor = ({ pkg: initialPkg }: PackageEditorProps) => {
+  const [pkg, setPkg] = useState(initialPkg);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [detailsForm, setDetailsForm] = useState({
+    name: initialPkg.name,
+    slug: initialPkg.slug,
+    description: initialPkg.description ?? '',
+    basePriceDollars: centsToDisplayDollars(initialPkg.basePriceCents)
+  });
+
+  const [modifierForm, setModifierForm] = useState({
+    name: '',
+    description: '',
+    priceDeltaDollars: '',
+    isRequired: false
+  });
+
+  const setFeedback = (msg: string | null, err: string | null = null) => {
+    setMessage(msg);
+    setError(err);
+  };
+
+  const updateDetails = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFeedback(null);
+
+    const basePriceCents = detailsForm.basePriceDollars
+      ? Math.round(parseFloat(detailsForm.basePriceDollars) * 100)
+      : undefined;
+
+    const response = await fetch(`/api/packages/${pkg.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: detailsForm.name,
+        slug: detailsForm.slug,
+        description: detailsForm.description || undefined,
+        basePriceCents
+      })
+    });
+
+    const payload = await response.json();
+
+    if (!payload.ok) {
+      setFeedback(null, payload.error?.message ?? 'Unable to update package.');
+      return;
+    }
+
+    setPkg((prev) => ({ ...prev, ...payload.data }));
+    setFeedback('Package details updated.');
+  };
+
+  const updateStatus = async () => {
+    setFeedback(null);
+
+    const response = await fetch(`/api/packages/${pkg.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: pkg.status })
+    });
+
+    const payload = await response.json();
+
+    if (!payload.ok) {
+      setFeedback(null, payload.error?.message ?? 'Unable to update status.');
+      return;
+    }
+
+    setPkg((prev) => ({ ...prev, status: payload.data.status }));
+    setFeedback('Status updated.');
+  };
+
+  const addModifier = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFeedback(null);
+
+    const priceDeltaCents = modifierForm.priceDeltaDollars
+      ? Math.round(parseFloat(modifierForm.priceDeltaDollars) * 100)
+      : undefined;
+
+    const response = await fetch(`/api/packages/${pkg.id}/modifiers`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        packageId: pkg.id,
+        name: modifierForm.name,
+        description: modifierForm.description || undefined,
+        priceDeltaCents,
+        isRequired: modifierForm.isRequired
+      })
+    });
+
+    const payload = await response.json();
+
+    if (!payload.ok) {
+      setFeedback(null, payload.error?.message ?? 'Unable to add modifier.');
+      return;
+    }
+
+    setPkg((prev) => ({ ...prev, modifiers: [...prev.modifiers, payload.data] }));
+    setModifierForm({ name: '', description: '', priceDeltaDollars: '', isRequired: false });
+    setFeedback('Modifier added.');
+  };
+
+  const removeModifier = async (modifierId: string) => {
+    setFeedback(null);
+
+    const response = await fetch(`/api/packages/${pkg.id}/modifiers/${modifierId}`, {
+      method: 'DELETE'
+    });
+
+    const payload = await response.json();
+
+    if (!payload.ok) {
+      setFeedback(null, payload.error?.message ?? 'Unable to remove modifier.');
+      return;
+    }
+
+    setPkg((prev) => ({
+      ...prev,
+      modifiers: prev.modifiers.filter((m) => m.id !== modifierId)
+    }));
+    setFeedback('Modifier removed.');
+  };
+
+  return (
+    <div className="space-y-8">
+      {/* Package details */}
+      <section className="rounded-lg border border-slate-200 bg-white p-6">
+        <h2 className="text-lg font-semibold text-slate-900">Package details</h2>
+        <form onSubmit={updateDetails} className="mt-4 space-y-4">
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Name
+            <input
+              value={detailsForm.name}
+              onChange={(e) => setDetailsForm((prev) => ({ ...prev, name: e.target.value }))}
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm"
+              required
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Slug
+            <input
+              value={detailsForm.slug}
+              onChange={(e) => setDetailsForm((prev) => ({ ...prev, slug: e.target.value }))}
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm"
+              required
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Description
+            <textarea
+              value={detailsForm.description}
+              onChange={(e) => setDetailsForm((prev) => ({ ...prev, description: e.target.value }))}
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm"
+              rows={3}
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Base price ($)
+            <input
+              value={detailsForm.basePriceDollars}
+              onChange={(e) =>
+                setDetailsForm((prev) => ({ ...prev, basePriceDollars: e.target.value }))
+              }
+              placeholder="e.g. 350"
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm"
+              inputMode="decimal"
+            />
+          </label>
+          <button
+            type="submit"
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
+          >
+            Save details
+          </button>
+        </form>
+      </section>
+
+      {/* Status */}
+      <section className="rounded-lg border border-slate-200 bg-white p-6">
+        <h2 className="text-lg font-semibold text-slate-900">Status</h2>
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <select
+            value={pkg.status}
+            onChange={(e) =>
+              setPkg((prev) => ({ ...prev, status: e.target.value as PackageStatus }))
+            }
+            className="rounded-md border border-slate-200 px-3 py-2 text-sm"
+          >
+            {statusOptions.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={updateStatus}
+            className="rounded-md border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+          >
+            Update status
+          </button>
+          <span className="text-sm text-slate-500">Current: {pkg.status}</span>
+        </div>
+      </section>
+
+      {/* Modifiers */}
+      <section className="rounded-lg border border-slate-200 bg-white p-6">
+        <h2 className="text-lg font-semibold text-slate-900">Modifiers</h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Add-ons or options that modify this package. Price delta can be negative for discounts.
+        </p>
+        <form onSubmit={addModifier} className="mt-4 space-y-4">
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Name
+            <input
+              value={modifierForm.name}
+              onChange={(e) => setModifierForm((prev) => ({ ...prev, name: e.target.value }))}
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm"
+              required
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Description
+            <input
+              value={modifierForm.description}
+              onChange={(e) =>
+                setModifierForm((prev) => ({ ...prev, description: e.target.value }))
+              }
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm"
+            />
+          </label>
+          <div className="flex flex-wrap gap-4">
+            <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+              Price delta ($)
+              <input
+                value={modifierForm.priceDeltaDollars}
+                onChange={(e) =>
+                  setModifierForm((prev) => ({ ...prev, priceDeltaDollars: e.target.value }))
+                }
+                placeholder="e.g. 50 or -25"
+                className="rounded-md border border-slate-200 px-3 py-2 text-sm"
+                inputMode="decimal"
+              />
+            </label>
+            <label className="flex items-center gap-2 self-end pb-2 text-sm font-medium text-slate-700">
+              <input
+                type="checkbox"
+                checked={modifierForm.isRequired}
+                onChange={(e) =>
+                  setModifierForm((prev) => ({ ...prev, isRequired: e.target.checked }))
+                }
+              />
+              Required
+            </label>
+          </div>
+          <button
+            type="submit"
+            className="rounded-md border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+          >
+            Add modifier
+          </button>
+        </form>
+
+        <div className="mt-6 space-y-3">
+          {pkg.modifiers.length === 0 ? (
+            <p className="text-sm text-slate-500">No modifiers yet.</p>
+          ) : (
+            pkg.modifiers.map((modifier) => (
+              <div
+                key={modifier.id}
+                className="flex flex-wrap items-center justify-between gap-4 rounded-md border border-slate-100 px-3 py-2"
+              >
+                <div>
+                  <p className="text-sm font-semibold text-slate-800">
+                    {modifier.name}
+                    {modifier.isRequired && (
+                      <span className="ml-2 text-xs font-normal text-slate-400">Required</span>
+                    )}
+                  </p>
+                  {modifier.description && (
+                    <p className="text-xs text-slate-500">{modifier.description}</p>
+                  )}
+                  {modifier.priceDeltaCents != null && (
+                    <p className="text-xs text-slate-500">
+                      {modifier.priceDeltaCents >= 0 ? '+' : ''}$
+                      {(modifier.priceDeltaCents / 100).toFixed(2)}
+                    </p>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => removeModifier(modifier.id)}
+                  className="text-xs font-semibold text-rose-600 hover:text-rose-500"
+                >
+                  Remove
+                </button>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+
+      {(message || error) && (
+        <div
+          className={`rounded-md border px-4 py-2 text-sm ${
+            error
+              ? 'border-rose-200 bg-rose-50 text-rose-700'
+              : 'border-emerald-200 bg-emerald-50 text-emerald-700'
+          }`}
+        >
+          {error ?? message}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PackageEditor;

--- a/apps/admin/app/packages/layout.tsx
+++ b/apps/admin/app/packages/layout.tsx
@@ -1,0 +1,17 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+import { getSessionCookieName, verifyAdminSessionToken } from '../lib/auth';
+
+const PackagesLayout = ({ children }: { children: ReactNode }) => {
+  const token = cookies().get(getSessionCookieName())?.value;
+
+  if (!verifyAdminSessionToken(token)) {
+    redirect('/login');
+  }
+
+  return <>{children}</>;
+};
+
+export default PackagesLayout;

--- a/apps/admin/app/packages/new/page.tsx
+++ b/apps/admin/app/packages/new/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+import NewPackageForm from '../components/NewPackageForm';
+
+const NewPackagePage = () => {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col gap-6 px-6 py-16">
+      <header>
+        <Link href="/packages" className="text-sm text-slate-500 hover:text-slate-700">
+          ← Back to packages
+        </Link>
+        <h1 className="mt-3 text-3xl font-semibold text-slate-900">New Package</h1>
+        <p className="text-sm text-slate-500">Create a new session package.</p>
+      </header>
+      <div className="rounded-lg border border-slate-200 bg-white p-6">
+        <NewPackageForm />
+      </div>
+    </main>
+  );
+};
+
+export default NewPackagePage;

--- a/apps/admin/app/packages/page.tsx
+++ b/apps/admin/app/packages/page.tsx
@@ -1,0 +1,75 @@
+import Link from 'next/link';
+
+import { type Package } from '@repo/db';
+import { prisma } from '@repo/db';
+
+export const dynamic = 'force-dynamic';
+
+const PackagesPage = async () => {
+  const packages = await prisma.package.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: {
+      _count: { select: { modifiers: true } }
+    }
+  });
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-6 px-6 py-16">
+      <header className="flex items-center justify-between">
+        <div>
+          <Link href="/galleries" className="text-sm text-slate-500 hover:text-slate-700">
+            ← Galleries
+          </Link>
+          <h1 className="mt-3 text-3xl font-semibold text-slate-900">Packages</h1>
+          <p className="text-sm text-slate-500">Manage session packages and modifiers.</p>
+        </div>
+        <Link
+          href="/packages/new"
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
+        >
+          New package
+        </Link>
+      </header>
+
+      <div className="rounded-lg border border-slate-200 bg-white">
+        <div className="grid grid-cols-[1.5fr_1fr_100px_140px] gap-4 border-b border-slate-200 px-4 py-3 text-sm font-semibold text-slate-600">
+          <span>Name</span>
+          <span>Status</span>
+          <span>Modifiers</span>
+          <span>Actions</span>
+        </div>
+        {packages.length === 0 ? (
+          <div className="px-4 py-6 text-sm text-slate-500">
+            No packages yet. Create the first one.
+          </div>
+        ) : (
+          <ul className="divide-y divide-slate-100">
+            {packages.map((pkg: Package & { _count: { modifiers: number } }) => (
+              <li
+                key={pkg.id}
+                className="grid grid-cols-[1.5fr_1fr_100px_140px] gap-4 px-4 py-4 text-sm"
+              >
+                <div>
+                  <p className="font-semibold text-slate-900">{pkg.name}</p>
+                  <p className="text-xs text-slate-500">/{pkg.slug}</p>
+                </div>
+                <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  {pkg.status}
+                </span>
+                <span className="text-xs text-slate-500">{pkg._count.modifiers}</span>
+                <Link
+                  href={`/packages/${pkg.id}`}
+                  className="text-sm font-semibold text-indigo-600 hover:text-indigo-500"
+                >
+                  Edit
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+};
+
+export default PackagesPage;


### PR DESCRIPTION
Add admin CMS pages for creating and editing session packages and modifiers. Follows the same auth and layout patterns as the gallery editor.

- /packages — list all packages with status and modifier count
- /packages/new — create a new package (name, slug, description, price)
- /packages/[id] — edit package details, status, and modifiers
- PackageEditor client component with inline add/remove for modifiers
- Prices entered as dollars, stored as cents
- Cross-nav link added to galleries list page

Also ran `prisma generate` to pick up the extended schema (Package, PackageModifier, BookingRequest, Inquiry models were not reflected in the generated client).

## PR Checklist

### 1) Summary of scope

- [ ] Briefly describe what changed (and what did **not** change).
- [ ] List affected apps/packages.

### 2) Why this change is needed

- [ ] Explain the user or engineering problem this PR solves.
- [ ] Link issue/ticket/spec (if applicable).

### 3) Local validation evidence

> Keep this aligned with CI in `.github/workflows/tests.yml`.

- [ ] `pnpm lint` — outcome: <!-- pass/fail + key notes -->
- [ ] `pnpm build` — outcome: <!-- pass/fail + key notes -->
- [ ] Relevant app sanity check(s) — outcome: <!-- e.g., `pnpm --filter <app> dev` + manual smoke result -->

Optional CI-parity checks (recommended when relevant):

- [ ] `pnpm typecheck` — outcome:
- [ ] `pnpm format:check` — outcome:
- [ ] `pnpm test` — outcome:

### 4) Risk / rollback notes

- [ ] Risk level: <!-- low/medium/high -->
- [ ] Main risks and impacted areas:
- [ ] Rollback plan (revert steps, flags, or migrations):

### 5) Follow-ups

- [ ] None.
- [ ] If needed, list follow-up tasks with owner and scope.
