### PR TITLE
feat: public packages API and /packages page

### DIFF
--- a/apps/admin/app/api/public/packages/route.ts
+++ b/apps/admin/app/api/public/packages/route.ts
@@ -1,0 +1,34 @@
+import { prisma } from '@repo/db';
+
+export const GET = async (): Promise<Response> => {
+  try {
+    const packages = await prisma.package.findMany({
+      where: { status: 'ACTIVE' },
+      orderBy: { createdAt: 'asc' },
+      include: {
+        modifiers: {
+          orderBy: { createdAt: 'asc' }
+        }
+      }
+    });
+
+    const payload = packages.map((pkg) => ({
+      id: pkg.id,
+      slug: pkg.slug,
+      name: pkg.name,
+      description: pkg.description,
+      basePriceCents: pkg.basePriceCents,
+      modifiers: pkg.modifiers.map((m) => ({
+        id: m.id,
+        name: m.name,
+        description: m.description,
+        priceDeltaCents: m.priceDeltaCents,
+        isRequired: m.isRequired
+      }))
+    }));
+
+    return Response.json(payload);
+  } catch {
+    return Response.json({ message: 'Unable to load packages.' }, { status: 500 });
+  }
+};

--- a/apps/evrydayarchive-web/app/packages/page.tsx
+++ b/apps/evrydayarchive-web/app/packages/page.tsx
@@ -1,0 +1,175 @@
+import Link from 'next/link';
+
+import { fetchPublicPackages, type PublicPackage } from '@repo/core';
+
+import { getServerEnv } from '../lib/env';
+
+export const dynamic = 'force-dynamic';
+
+const PackagesPage = async () => {
+  const { ADMIN_API_BASE_URL } = getServerEnv();
+  let packages: PublicPackage[] = [];
+
+  try {
+    packages = await fetchPublicPackages(ADMIN_API_BASE_URL, { next: { revalidate: 60 } });
+  } catch {
+    // Graceful degradation — page still renders without packages
+  }
+
+  return (
+    <main>
+      {/* ── Section 1: Intro / philosophy ────────────────────────────────── */}
+      <section className="px-4 pb-16 pt-16 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl">
+          <p className="mb-3 text-xs font-medium uppercase tracking-widest text-ink-faint">
+            Investment
+          </p>
+          <h1 className="mb-6 text-4xl font-semibold leading-tight tracking-tight text-ink sm:text-5xl">
+            The Curator&apos;s Notes
+          </h1>
+          <p className="mb-4 text-base leading-relaxed text-ink-muted">
+            Sessions are scoped around what you actually need — not bundled with extras that
+            don&apos;t serve you. Every package below is a starting point, not a ceiling.
+          </p>
+          <p className="text-base leading-relaxed text-ink-muted">
+            Don&apos;t see your situation here?{' '}
+            <Link
+              href="/inquire"
+              className="font-medium text-ink underline-offset-2 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
+            >
+              Reach out anyway
+            </Link>
+            . Custom sessions are always welcome.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Section 2: Package list ───────────────────────────────────────── */}
+      <section className="px-4 pb-24 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl">
+          {packages.length === 0 ? (
+            <div className="rounded-card border border-border px-8 py-16 text-center">
+              <p className="mb-6 text-base leading-relaxed text-ink-muted">
+                Packages are being finalized — check back soon.
+              </p>
+              <Link
+                href="/inquire"
+                className="text-sm font-medium text-ink underline-offset-2 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
+              >
+                In the meantime, reach out directly →
+              </Link>
+            </div>
+          ) : (
+            <div className="space-y-10">
+              {packages.map((pkg) => (
+                <PackageCard key={pkg.id} pkg={pkg} />
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* ── Section 3: End CTA ────────────────────────────────────────────── */}
+      <section className="bg-sun px-4 py-20 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl">
+          <p className="mb-1 text-xs font-medium uppercase tracking-widest text-ink-faint">
+            Still unsure?
+          </p>
+          <h2 className="mb-4 text-2xl font-semibold text-ink">
+            Custom situations are always welcome.
+          </h2>
+          <p className="mb-8 text-base leading-relaxed text-ink-muted">
+            If nothing above feels like the right fit, tell me what you have in mind. We&apos;ll
+            figure it out together.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/inquire"
+              className="rounded-card bg-accent px-6 py-3 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            >
+              Inquire
+            </Link>
+            <Link
+              href="/package-builder"
+              className="rounded-card border border-border px-6 py-3 text-sm font-medium text-ink-muted transition-colors duration-fast hover:border-ink-muted hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            >
+              Build your own
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+};
+
+export default PackagesPage;
+
+// ── Sub-components ──────────────────────────────────────────────────────────
+
+const formatPrice = (cents: number): string =>
+  new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency: 'CAD',
+    maximumFractionDigits: 0
+  }).format(cents / 100);
+
+const PackageCard = ({ pkg }: { pkg: PublicPackage }) => (
+  <article className="rounded-card border border-border bg-canvas p-8 shadow-warm-sm">
+    {/* Header */}
+    <header className="mb-6">
+      <h2 className="text-2xl font-semibold leading-snug text-ink">{pkg.name}</h2>
+      {pkg.description && (
+        <p className="mt-2 text-base leading-relaxed text-ink-muted">{pkg.description}</p>
+      )}
+      {pkg.basePriceCents != null && (
+        <p className="mt-3 text-sm font-medium text-ink-faint">
+          Starting at <span className="text-ink">{formatPrice(pkg.basePriceCents)}</span>
+        </p>
+      )}
+    </header>
+
+    {/* Modifiers */}
+    {pkg.modifiers.length > 0 && (
+      <div className="mb-6 border-t border-border pt-5">
+        <p className="mb-3 text-xs font-medium uppercase tracking-widest text-ink-faint">
+          Add-ons available
+        </p>
+        <ul className="space-y-2">
+          {pkg.modifiers.map((m) => (
+            <li key={m.id} className="flex items-baseline justify-between gap-4 text-sm">
+              <span className="text-ink-muted">
+                {m.name}
+                {m.isRequired && <span className="ml-2 text-xs text-ink-faint">(included)</span>}
+                {m.description && (
+                  <span className="ml-1 text-xs text-ink-faint">— {m.description}</span>
+                )}
+              </span>
+              {m.priceDeltaCents != null && !m.isRequired && (
+                <span className="flex-none text-xs text-ink-faint">
+                  {m.priceDeltaCents >= 0 ? '+' : ''}
+                  {formatPrice(m.priceDeltaCents)}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    )}
+
+    {/* CTAs */}
+    <div className="flex flex-wrap gap-3">
+      <Link
+        href={`/inquire?package=${pkg.slug}`}
+        className="rounded-card bg-accent px-5 py-2.5 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+      >
+        Inquire about this
+      </Link>
+      <Link
+        href={`/package-builder?package=${pkg.slug}`}
+        className="rounded-card border border-border px-5 py-2.5 text-sm font-medium text-ink-muted transition-colors duration-fast hover:border-ink-muted hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+      >
+        Open in builder
+      </Link>
+    </div>
+  </article>
+);

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -1,6 +1,7 @@
 export * from './client';
 export * from './errors';
 export * from './publicGalleries';
+export * from './publicPackages';
 export * from './response';
 export * from './types';
 export * from './validators';

--- a/packages/core/src/api/publicPackages.ts
+++ b/packages/core/src/api/publicPackages.ts
@@ -1,0 +1,28 @@
+import { PublicPackageListResponseSchema, type PublicPackage } from '../schemas/public-packages';
+import { PublicApiError, type PublicFetchOptions } from './publicGalleries';
+
+export const fetchPublicPackages = async (
+  baseUrl: string,
+  init?: PublicFetchOptions
+): Promise<PublicPackage[]> => {
+  const url = new URL('/api/public/packages', baseUrl);
+  const response = await fetch(url, { ...init, method: 'GET' });
+
+  if (!response.ok) {
+    const details = await response.json().catch(() => undefined);
+    throw new PublicApiError('Failed to load packages.', response.status, details);
+  }
+
+  const payload = await response.json();
+  const parsed = PublicPackageListResponseSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    throw new PublicApiError(
+      'Package list response did not match the expected schema.',
+      response.status,
+      parsed.error.format()
+    );
+  }
+
+  return parsed.data;
+};

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -5,6 +5,7 @@ export * from './schemas/booking-request';
 export * from './schemas/gallery';
 export * from './schemas/inquiry';
 export * from './schemas/package-builder';
+export * from './schemas/public-packages';
 
 export const newsletterSignupSchema = z.object({
   email: z.string().email(),

--- a/packages/core/src/schemas/public-packages.ts
+++ b/packages/core/src/schemas/public-packages.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const PublicPackageModifierSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  priceDeltaCents: z.number().int().nullable(),
+  isRequired: z.boolean()
+});
+
+export const PublicPackageSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  basePriceCents: z.number().int().nullable(),
+  modifiers: z.array(PublicPackageModifierSchema)
+});
+
+export const PublicPackageListResponseSchema = z.array(PublicPackageSchema);
+
+export type PublicPackage = z.infer<typeof PublicPackageSchema>;
+export type PublicPackageModifier = z.infer<typeof PublicPackageModifierSchema>;


### PR DESCRIPTION
Add the public-facing packages experience end to end.

@repo/core:
- PublicPackageSchema / PublicPackageListResponseSchema (Zod)
- fetchPublicPackages() API helper

apps/admin:
- GET /api/public/packages — returns ACTIVE packages with modifiers

apps/evrydayarchive-web:
- /packages page — "Curator's Notes" framing, one card per package, per-card "Inquire about this" + "Open in builder" CTAs, graceful empty state when no active packages exist

## PR Checklist

### 1) Summary of scope

- [ ] Briefly describe what changed (and what did **not** change).
- [ ] List affected apps/packages.

### 2) Why this change is needed

- [ ] Explain the user or engineering problem this PR solves.
- [ ] Link issue/ticket/spec (if applicable).

### 3) Local validation evidence

> Keep this aligned with CI in `.github/workflows/tests.yml`.

- [ ] `pnpm lint` — outcome: <!-- pass/fail + key notes -->
- [ ] `pnpm build` — outcome: <!-- pass/fail + key notes -->
- [ ] Relevant app sanity check(s) — outcome: <!-- e.g., `pnpm --filter <app> dev` + manual smoke result -->

Optional CI-parity checks (recommended when relevant):

- [ ] `pnpm typecheck` — outcome:
- [ ] `pnpm format:check` — outcome:
- [ ] `pnpm test` — outcome:

### 4) Risk / rollback notes

- [ ] Risk level: <!-- low/medium/high -->
- [ ] Main risks and impacted areas:
- [ ] Rollback plan (revert steps, flags, or migrations):

### 5) Follow-ups

- [ ] None.
- [ ] If needed, list follow-up tasks with owner and scope.
