### PR TITLE
feat(evrydayarchive-web): process and FAQ pages

### DIFF
--- a/apps/evrydayarchive-web/app/faq/faq-accordion.tsx
+++ b/apps/evrydayarchive-web/app/faq/faq-accordion.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState } from 'react';
+
+import { cn } from '../lib/cn';
+
+type FaqItem = {
+  question: string;
+  answer: string;
+};
+
+type FaqAccordionProps = {
+  items: FaqItem[];
+};
+
+export const FaqAccordion = ({ items }: FaqAccordionProps) => {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  const toggle = (index: number) => {
+    setOpenIndex((prev) => (prev === index ? null : index));
+  };
+
+  return (
+    <dl className="divide-y divide-border">
+      {items.map((item, index) => {
+        const isOpen = openIndex === index;
+
+        return (
+          <div key={index}>
+            <dt>
+              <button
+                type="button"
+                onClick={() => toggle(index)}
+                aria-expanded={isOpen}
+                className="flex w-full items-center justify-between gap-4 py-5 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
+              >
+                <span className="text-base font-medium text-ink">{item.question}</span>
+                <ChevronIcon isOpen={isOpen} />
+              </button>
+            </dt>
+            <dd
+              className={cn(
+                'overflow-hidden transition-all duration-standard',
+                isOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+              )}
+              aria-hidden={!isOpen}
+            >
+              <p className="pb-5 text-base leading-relaxed text-ink-muted">{item.answer}</p>
+            </dd>
+          </div>
+        );
+      })}
+    </dl>
+  );
+};
+
+const ChevronIcon = ({ isOpen }: { isOpen: boolean }) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    aria-hidden="true"
+    className={cn(
+      'flex-none text-ink-faint transition-transform duration-fast',
+      isOpen && 'rotate-180'
+    )}
+  >
+    <path
+      d="M4 6l4 4 4-4"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);

--- a/apps/evrydayarchive-web/app/faq/page.tsx
+++ b/apps/evrydayarchive-web/app/faq/page.tsx
@@ -1,0 +1,84 @@
+import Link from 'next/link';
+
+import { FaqAccordion } from './faq-accordion';
+
+const FAQ_ITEMS = [
+  {
+    question: 'What kinds of sessions do you photograph?',
+    answer:
+      'Families, couples, individuals, and everyday life moments — the connective tissue of ordinary days. If it matters to you, it matters to the archive. I also take on select commercial work when the fit is right.'
+  },
+  {
+    question: 'How far in advance should I book?',
+    answer:
+      'A few weeks is usually enough for most sessions. For busy seasons (spring and fall especially) or larger events, a month or two ahead gives us more flexibility with timing and light.'
+  },
+  {
+    question: 'Do you travel for sessions?',
+    answer:
+      "Yes. I'm based in Ottawa–Gatineau and available for travel across Canada. Travel sessions are priced to include logistics — reach out with your location and we'll work out the details."
+  },
+  {
+    question: 'What should we wear / how should we prepare?',
+    answer:
+      "Wear something you'd actually wear on a nice day out. Comfort matters more than coordinated outfits. I'll share a short prep note once we're confirmed — it covers everything from timing to what to bring."
+  },
+  {
+    question: 'How long until we receive the photos?',
+    answer:
+      "Most sessions are delivered within 2–3 weeks. Larger sessions or busy periods may take a little longer. I'll give you a specific timeline when we confirm the booking."
+  },
+  {
+    question: 'How many photos will we receive?',
+    answer:
+      'It depends on the session length and what unfolds — not a fixed number. Quality over quantity is the guiding principle. Every image in your gallery is there because it earned its place.'
+  },
+  {
+    question: 'Can we request specific shots or poses?',
+    answer:
+      "Absolutely. A short list of moments or groups you want documented is always helpful. Beyond that, I'll work in the background and let things breathe. The best images usually come from both."
+  },
+  {
+    question: "What if the weather doesn't cooperate?",
+    answer:
+      "We reschedule, no penalty. Overcast light is often beautiful — but rain, wind, or extreme heat isn't fun for anyone. I'll always be honest if I think we should move the date."
+  },
+  {
+    question: "I don't see a package that fits my situation. Can I still reach out?",
+    answer:
+      "Always. The listed packages are starting points. If your situation is different — unusual hours, a specific location, a larger group, or something entirely different — send a message and we'll figure it out."
+  }
+];
+
+const FaqPage = () => {
+  return (
+    <main className="px-4 py-16 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-2xl">
+        {/* Page header */}
+        <header className="mb-14">
+          <p className="mb-3 text-xs font-medium uppercase tracking-widest text-ink-faint">
+            Common questions
+          </p>
+          <h1 className="text-4xl font-semibold leading-tight tracking-tight text-ink sm:text-5xl">
+            FAQ
+          </h1>
+          <p className="mt-5 text-base leading-relaxed text-ink-muted">
+            If your question isn&apos;t here,{' '}
+            <Link
+              href="/inquire"
+              className="font-medium text-ink underline-offset-2 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
+            >
+              just ask
+            </Link>
+            .
+          </p>
+        </header>
+
+        {/* Accordion */}
+        <FaqAccordion items={FAQ_ITEMS} />
+      </div>
+    </main>
+  );
+};
+
+export default FaqPage;

--- a/apps/evrydayarchive-web/app/process/page.tsx
+++ b/apps/evrydayarchive-web/app/process/page.tsx
@@ -1,0 +1,85 @@
+import { Placard } from '../components/placard';
+
+const STEPS = [
+  {
+    number: '01',
+    title: 'Reach out',
+    description:
+      'Send a message with a rough idea of what you have in mind. No formal brief needed — just tell me the occasion, the people, and what feels important to you.'
+  },
+  {
+    number: '02',
+    title: 'We talk it through',
+    description:
+      'A short conversation to make sure we understand each other. I want to know what success looks like for you, and you should feel comfortable knowing what to expect from the day.'
+  },
+  {
+    number: '03',
+    title: 'The session',
+    description:
+      "We meet, we document. My job is to stay out of the way and let things unfold. There's no forced posing — just good light, honest moments, and time well spent."
+  },
+  {
+    number: '04',
+    title: 'Editing & delivery',
+    description:
+      'I work through the images carefully. Every photo that makes the cut is edited with intention — not over-processed, not undercooked. You receive a private gallery within the agreed timeline.'
+  },
+  {
+    number: '05',
+    title: 'After the archive',
+    description:
+      'The gallery is yours. Print, share, keep. If you want prints or albums arranged, I can help. And if you come back for another session someday, all the better.'
+  }
+];
+
+const ProcessPage = () => {
+  return (
+    <main className="px-4 py-16 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-3xl">
+        {/* Page header */}
+        <header className="mb-16">
+          <p className="mb-3 text-xs font-medium uppercase tracking-widest text-ink-faint">
+            How it works
+          </p>
+          <h1 className="text-4xl font-semibold leading-tight tracking-tight text-ink sm:text-5xl">
+            The process
+          </h1>
+          <p className="mt-5 max-w-lg text-base leading-relaxed text-ink-muted">
+            Simple, clear, and low-pressure. Here&apos;s what working together looks like from first
+            message to finished archive.
+          </p>
+        </header>
+
+        {/* Steps */}
+        <ol className="space-y-12">
+          {STEPS.map((step, index) => (
+            <li key={step.number} className="flex gap-6 sm:gap-10">
+              {/* Step number */}
+              <div className="flex-none pt-1">
+                <Placard title={step.number} size="sm" />
+              </div>
+
+              {/* Step content */}
+              <div className="flex-1">
+                {/* Connector line (except last) */}
+                <div className="relative">
+                  {index < STEPS.length - 1 && (
+                    <div
+                      className="absolute left-[-2.75rem] top-8 hidden h-full w-px bg-border sm:left-[-3.5rem] sm:block"
+                      aria-hidden="true"
+                    />
+                  )}
+                </div>
+                <h2 className="mb-2 text-lg font-semibold text-ink">{step.title}</h2>
+                <p className="text-base leading-relaxed text-ink-muted">{step.description}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </main>
+  );
+};
+
+export default ProcessPage;


### PR DESCRIPTION
Add two static-content supporting pages.

/process — 5-step exhibit layout using Placard components for step numbers, consistent with the archive gallery visual language.

/faq — 9 questions with an accessible accordion (keyboard-navigable, aria-expanded, smooth max-height transition). FaqAccordion is a client component; the page itself is a server component.

Copy is placeholder-quality and ready to be tuned before launch.

## PR Checklist

### 1) Summary of scope

- [ ] Briefly describe what changed (and what did **not** change).
- [ ] List affected apps/packages.

### 2) Why this change is needed

- [ ] Explain the user or engineering problem this PR solves.
- [ ] Link issue/ticket/spec (if applicable).

### 3) Local validation evidence

> Keep this aligned with CI in `.github/workflows/tests.yml`.

- [ ] `pnpm lint` — outcome: <!-- pass/fail + key notes -->
- [ ] `pnpm build` — outcome: <!-- pass/fail + key notes -->
- [ ] Relevant app sanity check(s) — outcome: <!-- e.g., `pnpm --filter <app> dev` + manual smoke result -->

Optional CI-parity checks (recommended when relevant):

- [ ] `pnpm typecheck` — outcome:
- [ ] `pnpm format:check` — outcome:
- [ ] `pnpm test` — outcome:

### 4) Risk / rollback notes

- [ ] Risk level: <!-- low/medium/high -->
- [ ] Main risks and impacted areas:
- [ ] Rollback plan (revert steps, flags, or migrations):

### 5) Follow-ups

- [ ] None.
- [ ] If needed, list follow-up tasks with owner and scope.
