### PR TITLE
fix: correct --color-sun token in dark mode

### DIFF
--- a/apps/evrydayarchive-web/app/globals.css
+++ b/apps/evrydayarchive-web/app/globals.css
@@ -18,7 +18,7 @@
   .dark {
     --color-canvas: #1b1a19;
     --color-surface: #262423;
-    --color-sun: #faf6ef;
+    --color-sun: #252321; /* warm-dark surface, mirrors sun's role in light mode */
     --color-ink: #ffffff;
     --color-ink-muted: #faf6ef;
     --color-ink-faint: rgba(250, 246, 239, 0.45);


### PR DESCRIPTION
Dark mode had --color-sun set to #faf6ef (near-white), causing sections that use bg-sun (e.g. the pricing philosophy section on Home) to render as a bright cream panel on the dark canvas. Changed to #252321, a warm dark tone that mirrors sun's subtle-differentiation role from light mode.

## PR Checklist

### 1) Summary of scope

- [ ] Briefly describe what changed (and what did **not** change).
- [ ] List affected apps/packages.

### 2) Why this change is needed

- [ ] Explain the user or engineering problem this PR solves.
- [ ] Link issue/ticket/spec (if applicable).

### 3) Local validation evidence

> Keep this aligned with CI in `.github/workflows/tests.yml`.

- [ ] `pnpm lint` — outcome: <!-- pass/fail + key notes -->
- [ ] `pnpm build` — outcome: <!-- pass/fail + key notes -->
- [ ] Relevant app sanity check(s) — outcome: <!-- e.g., `pnpm --filter <app> dev` + manual smoke result -->

Optional CI-parity checks (recommended when relevant):

- [ ] `pnpm typecheck` — outcome:
- [ ] `pnpm format:check` — outcome:
- [ ] `pnpm test` — outcome:

### 4) Risk / rollback notes

- [ ] Risk level: <!-- low/medium/high -->
- [ ] Main risks and impacted areas:
- [ ] Rollback plan (revert steps, flags, or migrations):

### 5) Follow-ups

- [ ] None.
- [ ] If needed, list follow-up tasks with owner and scope.
