### PR TITLE
feat: wire up real logo SVGs in site header

### DIFF
--- a/apps/evrydayarchive-web/app/components/site-header.tsx
+++ b/apps/evrydayarchive-web/app/components/site-header.tsx
@@ -142,7 +142,7 @@ export const SiteHeader = () => {
               className={cn(
                 'absolute z-10 origin-left transition-all duration-standard',
                 scrolledDown
-                  ? 'left-0 scale-[0.85] translate-x-0'
+                  ? 'left-0 scale-[0.65] translate-x-0'
                   : 'left-1/2 scale-100 -translate-x-1/2'
               )}
             >


### PR DESCRIPTION
Closes #34

## Summary
- Removes all `Logo` text component usage from the header — "EA" text never appears
- Desktop: always renders the horizontal lockup (`/logo/horizontal.svg` + dark variant)
- Mobile expanded: horizontal lockup in the centre slot (between hamburger and Inquire)
- Mobile compact: icon mark only (`/logo/icon.svg` + dark variant)

## Expand-on-tap behaviour (compact mode)
An absolutely-positioned `<button>` covers the full slim bar and calls `setScrolledDown(false)`. The logo `<Link>` sits above it at `z-10`, so tapping the icon navigates home while tapping anywhere else on the bar expands the header — no navigation.

## Test plan
- [ ] Desktop: horizontal lockup visible at all scroll positions, no "EA" text
- [ ] Mobile expanded: horizontal lockup in centre, hamburger left, Inquire right
- [ ] Mobile compact: icon mark only visible in slim bar
- [ ] Tap logo in compact mode → navigates to `/`
- [ ] Tap non-logo area of compact bar → expands to full header, no navigation
- [ ] Light and dark mode both render correct SVG variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)