### PR TITLE
admin: reviews type safety, tests, and migration fix

### DIFF
--- a/apps/admin/app/api/reviews/reviews.route.test.ts
+++ b/apps/admin/app/api/reviews/reviews.route.test.ts
@@ -1,0 +1,464 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  requireAdminSession: vi.fn(),
+  reviewFindMany: vi.fn(),
+  reviewCreate: vi.fn(),
+  reviewFindUnique: vi.fn(),
+  reviewUpdate: vi.fn(),
+  reviewDelete: vi.fn()
+}));
+
+vi.mock('../../lib/auth', () => ({
+  requireAdminSession: mocks.requireAdminSession
+}));
+
+vi.mock('../../../lib/auth', () => ({
+  requireAdminSession: mocks.requireAdminSession
+}));
+
+vi.mock('@repo/db', () => ({
+  prisma: {
+    review: {
+      findMany: mocks.reviewFindMany,
+      create: mocks.reviewCreate,
+      findUnique: mocks.reviewFindUnique,
+      update: mocks.reviewUpdate,
+      delete: mocks.reviewDelete
+    }
+  },
+  PrismaClientKnownRequestError: class PrismaClientKnownRequestError extends Error {
+    code: string;
+
+    constructor(message: string, { code }: { code: string }) {
+      super(message);
+      this.code = code;
+    }
+  }
+}));
+
+describe('GET /api/reviews', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mocks.requireAdminSession.mockReturnValue(null);
+  });
+
+  it('returns all reviews', async () => {
+    const records = [
+      { id: 'rev_1', clientName: 'Jane Smith', quote: 'Great!', gallery: null, imageAsset: null }
+    ];
+    mocks.reviewFindMany.mockResolvedValueOnce(records);
+
+    const { GET } = await import('./route');
+
+    const response = await GET(new Request('http://localhost/api/reviews'));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ ok: true, data: records });
+    expect(mocks.reviewFindMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty array when there are no reviews', async () => {
+    mocks.reviewFindMany.mockResolvedValueOnce([]);
+
+    const { GET } = await import('./route');
+
+    const response = await GET(new Request('http://localhost/api/reviews'));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ ok: true, data: [] });
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    mocks.requireAdminSession.mockReturnValue(
+      new Response(JSON.stringify({ ok: false }), { status: 401 })
+    );
+
+    const { GET } = await import('./route');
+
+    const response = await GET(new Request('http://localhost/api/reviews'));
+
+    expect(response.status).toBe(401);
+    expect(mocks.reviewFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/reviews', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mocks.requireAdminSession.mockReturnValue(null);
+  });
+
+  it('creates a review with a valid body', async () => {
+    const created = {
+      id: 'rev_1',
+      clientName: 'Jane Smith',
+      quote: 'Loved it.',
+      gallery: null,
+      imageAsset: null
+    };
+    mocks.reviewCreate.mockResolvedValueOnce(created);
+
+    const { POST } = await import('./route');
+
+    const response = await POST(
+      new Request('http://localhost/api/reviews', {
+        method: 'POST',
+        body: JSON.stringify({ clientName: 'Jane Smith', quote: 'Loved it.' }),
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(payload).toEqual({ ok: true, data: created });
+    expect(mocks.reviewCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a body missing clientName', async () => {
+    const { POST } = await import('./route');
+
+    const response = await POST(
+      new Request('http://localhost/api/reviews', {
+        method: 'POST',
+        body: JSON.stringify({ quote: 'Loved it.' }),
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.ok).toBe(false);
+    expect(payload.error.code).toBe('VALIDATION_ERROR');
+    expect(mocks.reviewCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body missing quote', async () => {
+    const { POST } = await import('./route');
+
+    const response = await POST(
+      new Request('http://localhost/api/reviews', {
+        method: 'POST',
+        body: JSON.stringify({ clientName: 'Jane Smith' }),
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.ok).toBe(false);
+    expect(mocks.reviewCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body with a malformed sessionDate', async () => {
+    const { POST } = await import('./route');
+
+    const response = await POST(
+      new Request('http://localhost/api/reviews', {
+        method: 'POST',
+        body: JSON.stringify({
+          clientName: 'Jane Smith',
+          quote: 'Great!',
+          sessionDate: '2024-09-15'
+        }),
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.ok).toBe(false);
+    expect(mocks.reviewCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    mocks.requireAdminSession.mockReturnValue(
+      new Response(JSON.stringify({ ok: false }), { status: 401 })
+    );
+
+    const { POST } = await import('./route');
+
+    const response = await POST(
+      new Request('http://localhost/api/reviews', {
+        method: 'POST',
+        body: JSON.stringify({ clientName: 'Jane Smith', quote: 'Loved it.' }),
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.reviewCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/reviews/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mocks.requireAdminSession.mockReturnValue(null);
+  });
+
+  it('returns a review by id', async () => {
+    const record = {
+      id: 'rev_1',
+      clientName: 'Jane Smith',
+      quote: 'Loved it.',
+      gallery: null,
+      imageAsset: null
+    };
+    mocks.reviewFindUnique.mockResolvedValueOnce(record);
+
+    const { GET } = await import('./[id]/route');
+
+    const response = await GET(new Request('http://localhost/api/reviews/rev_1'), {
+      params: { id: 'rev_1' }
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ ok: true, data: record });
+  });
+
+  it('returns 404 when the review does not exist', async () => {
+    mocks.reviewFindUnique.mockResolvedValueOnce(null);
+
+    const { GET } = await import('./[id]/route');
+
+    const response = await GET(new Request('http://localhost/api/reviews/rev_missing'), {
+      params: { id: 'rev_missing' }
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(payload.ok).toBe(false);
+    expect(payload.error.code).toBe('NOT_FOUND');
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    mocks.requireAdminSession.mockReturnValue(
+      new Response(JSON.stringify({ ok: false }), { status: 401 })
+    );
+
+    const { GET } = await import('./[id]/route');
+
+    const response = await GET(new Request('http://localhost/api/reviews/rev_1'), {
+      params: { id: 'rev_1' }
+    });
+
+    expect(response.status).toBe(401);
+    expect(mocks.reviewFindUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/reviews/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mocks.requireAdminSession.mockReturnValue(null);
+  });
+
+  it('updates a review with a valid body', async () => {
+    const updated = {
+      id: 'rev_1',
+      clientName: 'Jane Smith',
+      quote: 'Updated quote.',
+      gallery: null,
+      imageAsset: null
+    };
+    mocks.reviewUpdate.mockResolvedValueOnce(updated);
+
+    const { PUT } = await import('./[id]/route');
+
+    const response = await PUT(
+      new Request('http://localhost/api/reviews/rev_1', {
+        method: 'PUT',
+        body: JSON.stringify({ quote: 'Updated quote.' }),
+        headers: { 'Content-Type': 'application/json' }
+      }),
+      { params: { id: 'rev_1' } }
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ ok: true, data: updated });
+    expect(mocks.reviewUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'rev_1' } })
+    );
+  });
+
+  it('converts an empty galleryId string to null', async () => {
+    const updated = {
+      id: 'rev_1',
+      clientName: 'Jane',
+      quote: 'Great!',
+      gallery: null,
+      imageAsset: null
+    };
+    mocks.reviewUpdate.mockResolvedValueOnce(updated);
+
+    const { PUT } = await import('./[id]/route');
+
+    await PUT(
+      new Request('http://localhost/api/reviews/rev_1', {
+        method: 'PUT',
+        body: JSON.stringify({ galleryId: '' }),
+        headers: { 'Content-Type': 'application/json' }
+      }),
+      { params: { id: 'rev_1' } }
+    );
+
+    expect(mocks.reviewUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ galleryId: null }) })
+    );
+  });
+
+  it('converts an empty imageAssetId string to null', async () => {
+    const updated = {
+      id: 'rev_1',
+      clientName: 'Jane',
+      quote: 'Great!',
+      gallery: null,
+      imageAsset: null
+    };
+    mocks.reviewUpdate.mockResolvedValueOnce(updated);
+
+    const { PUT } = await import('./[id]/route');
+
+    await PUT(
+      new Request('http://localhost/api/reviews/rev_1', {
+        method: 'PUT',
+        body: JSON.stringify({ imageAssetId: '' }),
+        headers: { 'Content-Type': 'application/json' }
+      }),
+      { params: { id: 'rev_1' } }
+    );
+
+    expect(mocks.reviewUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ imageAssetId: null }) })
+    );
+  });
+
+  it('returns 404 for a P2025 error', async () => {
+    const { PrismaClientKnownRequestError } = await import('@repo/db');
+    mocks.reviewUpdate.mockRejectedValueOnce(
+      new PrismaClientKnownRequestError('Not found', { code: 'P2025', clientVersion: '5.18.0' })
+    );
+
+    const { PUT } = await import('./[id]/route');
+
+    const response = await PUT(
+      new Request('http://localhost/api/reviews/rev_missing', {
+        method: 'PUT',
+        body: JSON.stringify({ quote: 'Updated.' }),
+        headers: { 'Content-Type': 'application/json' }
+      }),
+      { params: { id: 'rev_missing' } }
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(payload.error.code).toBe('NOT_FOUND');
+  });
+
+  it('rejects an invalid body', async () => {
+    const { PUT } = await import('./[id]/route');
+
+    const response = await PUT(
+      new Request('http://localhost/api/reviews/rev_1', {
+        method: 'PUT',
+        body: JSON.stringify({ clientName: '' }),
+        headers: { 'Content-Type': 'application/json' }
+      }),
+      { params: { id: 'rev_1' } }
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe('VALIDATION_ERROR');
+    expect(mocks.reviewUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    mocks.requireAdminSession.mockReturnValue(
+      new Response(JSON.stringify({ ok: false }), { status: 401 })
+    );
+
+    const { PUT } = await import('./[id]/route');
+
+    const response = await PUT(
+      new Request('http://localhost/api/reviews/rev_1', {
+        method: 'PUT',
+        body: JSON.stringify({ quote: 'Updated.' }),
+        headers: { 'Content-Type': 'application/json' }
+      }),
+      { params: { id: 'rev_1' } }
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.reviewUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/reviews/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mocks.requireAdminSession.mockReturnValue(null);
+  });
+
+  it('deletes a review', async () => {
+    mocks.reviewDelete.mockResolvedValueOnce({ id: 'rev_1' });
+
+    const { DELETE } = await import('./[id]/route');
+
+    const response = await DELETE(
+      new Request('http://localhost/api/reviews/rev_1', { method: 'DELETE' }),
+      { params: { id: 'rev_1' } }
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ ok: true, data: { deleted: true } });
+    expect(mocks.reviewDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'rev_1' } })
+    );
+  });
+
+  it('returns 404 for a P2025 error', async () => {
+    const { PrismaClientKnownRequestError } = await import('@repo/db');
+    mocks.reviewDelete.mockRejectedValueOnce(
+      new PrismaClientKnownRequestError('Not found', { code: 'P2025', clientVersion: '5.18.0' })
+    );
+
+    const { DELETE } = await import('./[id]/route');
+
+    const response = await DELETE(
+      new Request('http://localhost/api/reviews/rev_missing', { method: 'DELETE' }),
+      { params: { id: 'rev_missing' } }
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(payload.error.code).toBe('NOT_FOUND');
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    mocks.requireAdminSession.mockReturnValue(
+      new Response(JSON.stringify({ ok: false }), { status: 401 })
+    );
+
+    const { DELETE } = await import('./[id]/route');
+
+    const response = await DELETE(
+      new Request('http://localhost/api/reviews/rev_1', { method: 'DELETE' }),
+      { params: { id: 'rev_1' } }
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.reviewDelete).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/schemas/review.test.ts
+++ b/packages/core/src/schemas/review.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  PublicReviewListSchema,
+  PublicReviewSchema,
+  ReviewCreateSchema,
+  ReviewUpdateSchema
+} from './review';
+
+describe('ReviewCreateSchema', () => {
+  it('accepts a valid payload with all fields', () => {
+    const result = ReviewCreateSchema.safeParse({
+      clientName: 'Jane Smith',
+      quote: 'Absolutely loved the experience.',
+      sessionType: 'Family session',
+      sessionDate: '2024-09-15T00:00:00.000Z',
+      galleryId: 'gal_123',
+      imageAssetId: 'img_456',
+      isPublished: true,
+      featuredOnHome: false
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid payload with required fields only', () => {
+    const result = ReviewCreateSchema.safeParse({
+      clientName: 'Jane Smith',
+      quote: 'Absolutely loved the experience.'
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a missing clientName', () => {
+    const result = ReviewCreateSchema.safeParse({
+      quote: 'Great session!'
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty clientName', () => {
+    const result = ReviewCreateSchema.safeParse({
+      clientName: '',
+      quote: 'Great session!'
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing quote', () => {
+    const result = ReviewCreateSchema.safeParse({
+      clientName: 'Jane Smith'
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty quote', () => {
+    const result = ReviewCreateSchema.safeParse({
+      clientName: 'Jane Smith',
+      quote: ''
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a sessionDate that is not a full datetime string', () => {
+    const result = ReviewCreateSchema.safeParse({
+      clientName: 'Jane Smith',
+      quote: 'Great session!',
+      sessionDate: '2024-09-15'
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a sessionDate that is not a valid date at all', () => {
+    const result = ReviewCreateSchema.safeParse({
+      clientName: 'Jane Smith',
+      quote: 'Great session!',
+      sessionDate: 'not-a-date'
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ReviewUpdateSchema', () => {
+  it('accepts a partial update', () => {
+    const result = ReviewUpdateSchema.safeParse({
+      quote: 'Updated quote.'
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an empty object', () => {
+    const result = ReviewUpdateSchema.safeParse({});
+
+    expect(result.success).toBe(true);
+  });
+
+  it('still rejects an empty clientName when provided', () => {
+    const result = ReviewUpdateSchema.safeParse({
+      clientName: ''
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('still rejects a malformed sessionDate when provided', () => {
+    const result = ReviewUpdateSchema.safeParse({
+      sessionDate: '2024-09-15'
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('PublicReviewSchema', () => {
+  it('parses a full public review', () => {
+    const result = PublicReviewSchema.safeParse({
+      id: 'rev_1',
+      clientName: 'Jane Smith',
+      quote: 'Amazing!',
+      sessionType: 'Family session',
+      sessionDate: '2024-09-15T00:00:00.000Z',
+      gallerySlug: 'fall-highlights',
+      image: {
+        src: 'https://example.com/photo.jpg',
+        alt: 'Family portrait',
+        width: 1200,
+        height: 800
+      }
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('parses a review with all nullable fields set to null', () => {
+    const result = PublicReviewSchema.safeParse({
+      id: 'rev_2',
+      clientName: 'John Doe',
+      quote: 'Loved it.',
+      sessionType: null,
+      sessionDate: null,
+      gallerySlug: null,
+      image: null
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a review with an invalid image URL', () => {
+    const result = PublicReviewSchema.safeParse({
+      id: 'rev_3',
+      clientName: 'John Doe',
+      quote: 'Loved it.',
+      sessionType: null,
+      sessionDate: null,
+      gallerySlug: null,
+      image: {
+        src: 'not-a-url',
+        alt: 'Photo',
+        width: null,
+        height: null
+      }
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('PublicReviewListSchema', () => {
+  it('parses an empty array', () => {
+    const result = PublicReviewListSchema.safeParse([]);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(0);
+    }
+  });
+
+  it('parses a list of reviews', () => {
+    const result = PublicReviewListSchema.safeParse([
+      {
+        id: 'rev_1',
+        clientName: 'Jane',
+        quote: 'Great!',
+        sessionType: null,
+        sessionDate: null,
+        gallerySlug: null,
+        image: null
+      }
+    ]);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(1);
+    }
+  });
+});

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,6 +11,7 @@
     "schema": "prisma/schema.prisma"
   },
   "scripts": {
+    "postinstall": "prisma generate",
     "generate": "prisma generate",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",

--- a/packages/db/prisma/migrations/20260320000001_revert_global_modifier_library/migration.sql
+++ b/packages/db/prisma/migrations/20260320000001_revert_global_modifier_library/migration.sql
@@ -12,19 +12,29 @@ DROP INDEX IF EXISTS "PackageModifier_modifierId_idx";
 -- Remove modifierId column
 ALTER TABLE "PackageModifier" DROP COLUMN IF EXISTS "modifierId";
 
--- Restore original columns
-ALTER TABLE "PackageModifier"
-    ADD COLUMN "name" TEXT NOT NULL DEFAULT '',
-    ADD COLUMN "description" TEXT,
-    ADD COLUMN "type" "ModifierType" NOT NULL DEFAULT 'CHECKBOX',
-    ADD COLUMN "priceDeltaCents" INTEGER,
-    ADD COLUMN "config" JSONB;
-
--- Remove the temporary default on name
-ALTER TABLE "PackageModifier" ALTER COLUMN "name" DROP DEFAULT;
+-- Restore original columns (conditional to handle both fresh DBs and ones that had the forward migration applied)
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='PackageModifier' AND column_name='name') THEN
+        ALTER TABLE "PackageModifier" ADD COLUMN "name" TEXT NOT NULL DEFAULT '';
+        ALTER TABLE "PackageModifier" ALTER COLUMN "name" DROP DEFAULT;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='PackageModifier' AND column_name='description') THEN
+        ALTER TABLE "PackageModifier" ADD COLUMN "description" TEXT;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='PackageModifier' AND column_name='type') THEN
+        ALTER TABLE "PackageModifier" ADD COLUMN "type" "ModifierType" NOT NULL DEFAULT 'CHECKBOX';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='PackageModifier' AND column_name='priceDeltaCents') THEN
+        ALTER TABLE "PackageModifier" ADD COLUMN "priceDeltaCents" INTEGER;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='PackageModifier' AND column_name='config') THEN
+        ALTER TABLE "PackageModifier" ADD COLUMN "config" JSONB;
+    END IF;
+END$$;
 
 -- Restore original unique constraint and index
-CREATE UNIQUE INDEX "PackageModifier_packageId_name_key" ON "PackageModifier"("packageId", "name");
+CREATE UNIQUE INDEX IF NOT EXISTS "PackageModifier_packageId_name_key" ON "PackageModifier"("packageId", "name");
 
 -- Drop the Modifier table
 DROP TABLE IF EXISTS "Modifier";

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -14,6 +14,7 @@ export type {
   PackageModifier,
   PackageStatus,
   Prisma as PrismaTypes,
+  Review,
   TimeSlot,
   TimeSlotStatus,
   WaitlistEntry


### PR DESCRIPTION
## Summary

- **Fix idempotent migration** — `revert_global_modifier_library` was failing on fresh DBs because the forward migration it assumed was never committed to git; replaced bare `ADD COLUMN` / `CREATE INDEX` with conditional `DO $$` blocks and `IF NOT EXISTS`
- **Export `Review` type** from `@repo/db` — it was the only Prisma model not re-exported
- **Add `postinstall` prisma generate** to `@repo/db` so Vercel builds always regenerate the Prisma client (root cause of the reviews page runtime error)
- **37 new tests** — 17 schema tests + 20 API route tests covering the full reviews surface area

## Test plan

- [ ] `pnpm test` — all 221 tests pass
- [ ] `pnpm typecheck` — no errors
- [ ] `pnpm lint` — no warnings
- [ ] Run `pnpm --filter @repo/db db:migrate` against a fresh DB to confirm the fixed migration applies cleanly

## Related

Closes #63 (staging DB setup) is tracked separately as future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)