### PR TITLE
fix: bypass Vercel 4.5MB limit with direct browser-to-Cloudinary upload

### DIFF
--- a/apps/admin/app/api/galleries/[id]/images/confirm/route.ts
+++ b/apps/admin/app/api/galleries/[id]/images/confirm/route.ts
@@ -1,0 +1,46 @@
+import { ConfirmUploadSchema, createApiError, jsonError, jsonOk, parseJson } from '@repo/core';
+import { prisma } from '@repo/db';
+
+import { requireAdminSession } from '../../../../../lib/auth';
+
+export const POST = async (
+  req: Request,
+  { params }: { params: { id: string } }
+): Promise<Response> => {
+  const authError = requireAdminSession(req);
+  if (authError) return authError;
+
+  const gallery = await prisma.gallery.findUnique({
+    where: { id: params.id },
+    select: { id: true }
+  });
+
+  if (!gallery) {
+    return jsonError(createApiError('NOT_FOUND', 'Gallery not found.'));
+  }
+
+  const result = await parseJson(req, ConfirmUploadSchema);
+  if (!result.ok) {
+    return jsonError(result.error);
+  }
+
+  const { secureUrl, width, height, alt } = result.data;
+
+  const [currentCount, existingCover, imageAsset] = await Promise.all([
+    prisma.galleryImage.count({ where: { galleryId: params.id } }),
+    prisma.galleryImage.findFirst({ where: { galleryId: params.id, isCover: true } }),
+    prisma.imageAsset.create({ data: { src: secureUrl, alt, width, height } })
+  ]);
+
+  const galleryImage = await prisma.galleryImage.create({
+    data: {
+      galleryId: params.id,
+      imageAssetId: imageAsset.id,
+      order: currentCount + 1,
+      isCover: !existingCover
+    },
+    include: { imageAsset: true }
+  });
+
+  return jsonOk(galleryImage, { status: 201 });
+};

--- a/apps/admin/app/api/galleries/[id]/images/signature/route.ts
+++ b/apps/admin/app/api/galleries/[id]/images/signature/route.ts
@@ -1,0 +1,26 @@
+import { createApiError, jsonError, jsonOk } from '@repo/core';
+import { prisma } from '@repo/db';
+
+import { requireAdminSession } from '../../../../../lib/auth';
+import { generateUploadSignature } from '../../../../../lib/cloudinary';
+
+export const GET = async (
+  req: Request,
+  { params }: { params: { id: string } }
+): Promise<Response> => {
+  const authError = requireAdminSession(req);
+  if (authError) return authError;
+
+  const gallery = await prisma.gallery.findUnique({
+    where: { id: params.id },
+    select: { slug: true }
+  });
+
+  if (!gallery) {
+    return jsonError(createApiError('NOT_FOUND', 'Gallery not found.'));
+  }
+
+  const sigData = generateUploadSignature(`galleries/${gallery.slug}`);
+
+  return jsonOk(sigData);
+};

--- a/apps/admin/app/galleries/components/GalleryEditor.tsx
+++ b/apps/admin/app/galleries/components/GalleryEditor.tsx
@@ -136,38 +136,95 @@ const GalleryEditor = ({ gallery }: { gallery: Gallery }) => {
     setError(null);
     setMessage(null);
 
+    // Fetch a signed upload signature from the server once for the batch.
+    let sigData: {
+      signature: string;
+      timestamp: number;
+      folder: string;
+      apiKey: string;
+      cloudName: string;
+    };
+    try {
+      const sigRes = await fetch(`/api/galleries/${gallery.id}/images/signature`);
+      const sigPayload = await sigRes.json();
+      if (!sigPayload.ok)
+        throw new Error(sigPayload.error?.message ?? 'Failed to get upload signature.');
+      sigData = sigPayload.data;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to get upload signature.');
+      setUploading(false);
+      return;
+    }
+
     for (const item of pending) {
       setQueue((prev) =>
         prev.map((q) => (q.localId === item.localId ? { ...q, status: 'uploading' } : q))
       );
 
-      const formData = new FormData();
-      formData.append('file', item.file);
-      formData.append('alt', item.alt);
+      try {
+        // Step 1: Upload directly from the browser to Cloudinary (bypasses Vercel payload limit).
+        const cloudinaryForm = new FormData();
+        cloudinaryForm.append('file', item.file);
+        cloudinaryForm.append('api_key', sigData.apiKey);
+        cloudinaryForm.append('timestamp', String(sigData.timestamp));
+        cloudinaryForm.append('signature', sigData.signature);
+        cloudinaryForm.append('folder', sigData.folder);
 
-      const response = await fetch(`/api/galleries/${gallery.id}/images/upload`, {
-        method: 'POST',
-        body: formData
-      });
-
-      const payload = await response.json();
-
-      if (!payload.ok) {
-        setQueue((prev) =>
-          prev.map((q) =>
-            q.localId === item.localId
-              ? { ...q, status: 'error', errorMsg: payload.error?.message ?? 'Upload failed.' }
-              : q
-          )
+        const cloudinaryRes = await fetch(
+          `https://api.cloudinary.com/v1_1/${sigData.cloudName}/image/upload`,
+          { method: 'POST', body: cloudinaryForm }
         );
-      } else {
+
+        if (!cloudinaryRes.ok) {
+          const errData = await cloudinaryRes.json().catch(() => ({}));
+          throw new Error(
+            (errData as { error?: { message?: string } }).error?.message ??
+              'Cloudinary upload failed.'
+          );
+        }
+
+        const cloudinaryData = (await cloudinaryRes.json()) as {
+          secure_url: string;
+          width: number;
+          height: number;
+        };
+
+        // Step 2: Save the Cloudinary result to the database.
+        const confirmRes = await fetch(`/api/galleries/${gallery.id}/images/confirm`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            secureUrl: cloudinaryData.secure_url,
+            width: cloudinaryData.width,
+            height: cloudinaryData.height,
+            alt: item.alt
+          })
+        });
+
+        const confirmPayload = await confirmRes.json();
+        if (!confirmPayload.ok) {
+          throw new Error(confirmPayload.error?.message ?? 'Failed to save image.');
+        }
+
         setQueue((prev) =>
           prev.map((q) => (q.localId === item.localId ? { ...q, status: 'done' } : q))
         );
         setGalleryState((prev) => ({
           ...prev,
-          images: [...prev.images, payload.data].sort((a, b) => a.order - b.order)
+          images: [...prev.images, confirmPayload.data].sort((a, b) => a.order - b.order)
         }));
+      } catch (err) {
+        setQueue((prev) =>
+          prev.map((q) =>
+            q.localId === item.localId
+              ? {
+                  ...q,
+                  status: 'error',
+                  errorMsg: err instanceof Error ? err.message : 'Upload failed.'
+                }
+              : q
+          )
+        );
       }
     }
 

--- a/apps/admin/app/lib/cloudinary.ts
+++ b/apps/admin/app/lib/cloudinary.ts
@@ -1,3 +1,5 @@
+import crypto from 'crypto';
+
 import { v2 as cloudinary } from 'cloudinary';
 
 cloudinary.config({
@@ -11,6 +13,31 @@ type UploadResult = {
   public_id: string;
   width: number;
   height: number;
+};
+
+type SignatureResult = {
+  signature: string;
+  timestamp: number;
+  folder: string;
+  apiKey: string;
+  cloudName: string;
+};
+
+export const generateUploadSignature = (folder: string): SignatureResult => {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const paramsToSign = `folder=${folder}&timestamp=${timestamp}`;
+  const signature = crypto
+    .createHash('sha1')
+    .update(paramsToSign + process.env.CLOUDINARY_API_SECRET)
+    .digest('hex');
+
+  return {
+    signature,
+    timestamp,
+    folder,
+    apiKey: process.env.CLOUDINARY_API_KEY!,
+    cloudName: process.env.CLOUDINARY_CLOUD_NAME!
+  };
 };
 
 export const uploadToCloudinary = (buffer: Buffer, folder: string): Promise<UploadResult> =>

--- a/packages/core/src/schemas/gallery.ts
+++ b/packages/core/src/schemas/gallery.ts
@@ -29,6 +29,13 @@ export const GalleryImageAttachSchema = z.object({
   isCover: z.boolean().optional()
 });
 
+export const ConfirmUploadSchema = z.object({
+  secureUrl: z.string().url(),
+  width: z.number().int().positive(),
+  height: z.number().int().positive(),
+  alt: z.string().min(1)
+});
+
 export const GalleryPublishSchema = z.object({
   status: GalleryStatusSchema
 });


### PR DESCRIPTION
## Summary
- Replaces server-side file proxying with a 3-step direct upload flow: browser fetches a signed token → uploads directly to Cloudinary → POSTs the result to a new `/confirm` route to persist to the DB
- Adds `GET /api/galleries/[id]/images/signature` — generates a Cloudinary signed upload token server-side
- Adds `POST /api/galleries/[id]/images/confirm` — saves the Cloudinary result (`secureUrl`, `width`, `height`, `alt`) as `ImageAsset` + `GalleryImage` in the DB
- Adds `ConfirmUploadSchema` to `@repo/core` for validation

## Test plan
- [ ] Upload a photo >4.5MB via the deployed admin on Vercel — should succeed where it previously 413'd
- [ ] Verify the image appears in the gallery editor after upload
- [ ] Verify cover image logic still works (first upload sets cover)
- [ ] Upload multiple photos in a batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)