### PR TITLE
fix: redirect /coming-soon to / when coming-soon mode is off

### DIFF
--- a/apps/evrydayarchive-web/middleware.ts
+++ b/apps/evrydayarchive-web/middleware.ts
@@ -3,9 +3,15 @@ import { type NextRequest, NextResponse } from 'next/server';
 const COMING_SOON = process.env.NEXT_PUBLIC_COMING_SOON === 'true';
 
 export function middleware(request: NextRequest) {
-  if (!COMING_SOON) return NextResponse.next();
-
   const { pathname } = request.nextUrl;
+
+  // When coming-soon mode is off, redirect the coming-soon page to home
+  if (!COMING_SOON) {
+    if (pathname === '/coming-soon') {
+      return NextResponse.redirect(new URL('/', request.url));
+    }
+    return NextResponse.next();
+  }
 
   // Pass through the coming-soon page, API routes, and any static file (has a file extension)
   if (pathname === '/coming-soon' || pathname.startsWith('/api/') || /\.\w+$/.test(pathname)) {


### PR DESCRIPTION
## Summary
- When `NEXT_PUBLIC_COMING_SOON` is not `true`, visiting `/coming-soon` now redirects to `/` instead of rendering the coming-soon page
- Existing behavior when coming-soon mode is on is unchanged

## Test plan
- [ ] With `NEXT_PUBLIC_COMING_SOON=false` (or unset): navigate to `/coming-soon` and confirm redirect to `/`
- [ ] With `NEXT_PUBLIC_COMING_SOON=true`: confirm `/coming-soon` still loads normally and all other routes redirect to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)