### PR TITLE
feat: Spring Sale promotional infrastructure

### DIFF
--- a/apps/evrydayarchive-web/app/book/booking-form.tsx
+++ b/apps/evrydayarchive-web/app/book/booking-form.tsx
@@ -16,6 +16,7 @@ import { LocationPicker } from '../components/location-picker';
 import type { CoreLocation } from '../components/location-picker';
 import { DatePicker } from './date-picker';
 import { TimePicker } from './time-picker';
+import { SALE } from '../lib/sale';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -24,6 +25,8 @@ type Props = {
   resolvedModifiers: PublicPackageModifier[];
   modifierValues: Record<string, number>;
   estimatedTotalCents: number | undefined;
+  /** Defined during May 2026 only — 10% April Sale discount applied. */
+  discountedTotalCents: number | undefined;
   timeSlots: TimeSlot[];
   locationWindows: LocationWindow[];
 };
@@ -117,6 +120,7 @@ export const BookingForm = ({
   resolvedModifiers,
   modifierValues,
   estimatedTotalCents,
+  discountedTotalCents,
   timeSlots,
   locationWindows
 }: Props) => {
@@ -218,7 +222,9 @@ export const BookingForm = ({
       packageName: pkg?.name,
       modifierIds: resolvedModifiers.filter((m) => !m.isRequired).map((m) => m.id),
       modifierValues: Object.keys(modifierValues).length > 0 ? modifierValues : undefined,
-      estimatedTotalCents
+      // Use the discounted total when the April Sale applies, so the booking record
+      // reflects what the customer was actually quoted.
+      estimatedTotalCents: discountedTotalCents ?? estimatedTotalCents
     };
 
     try {
@@ -283,11 +289,28 @@ export const BookingForm = ({
             </ul>
           )}
           {estimatedTotalCents != null && (
-            <div className="mt-3 flex items-baseline justify-between border-t border-border pt-3">
-              <span className="text-xs text-ink-faint">Estimated total</span>
-              <span className="text-sm font-semibold text-ink">
-                {formatPrice(estimatedTotalCents)}
-              </span>
+            <div className="mt-3 border-t border-border pt-3">
+              {discountedTotalCents != null && (
+                <div className="mb-2 flex items-center gap-1.5 rounded-card border border-accent/20 bg-accent/5 px-2.5 py-1.5">
+                  <span className="font-mono text-[9px] font-bold uppercase tracking-widest text-accent/80">
+                    {SALE.name}
+                  </span>
+                  <span className="text-xs text-accent">{SALE.discountLabel}</span>
+                </div>
+              )}
+              <div className="flex items-baseline justify-between">
+                <span className="text-xs text-ink-faint">Estimated total</span>
+                <div className="flex items-baseline gap-2">
+                  {discountedTotalCents != null && (
+                    <span className="text-xs tabular-nums text-ink-faint line-through">
+                      {formatPrice(estimatedTotalCents)}
+                    </span>
+                  )}
+                  <span className="text-sm font-semibold text-ink">
+                    {formatPrice(discountedTotalCents ?? estimatedTotalCents)}
+                  </span>
+                </div>
+              </div>
             </div>
           )}
         </div>

--- a/apps/evrydayarchive-web/app/book/booking-form.tsx
+++ b/apps/evrydayarchive-web/app/book/booking-form.tsx
@@ -293,11 +293,19 @@ export const BookingForm = ({
               <p className="mb-1 text-xs font-medium uppercase tracking-widest text-ink-faint">
                 Your selection
               </p>
-              <p className="text-base font-semibold text-ink">{pkg.name}</p>
+              <div className="flex items-baseline justify-between gap-3">
+                <p className="text-base font-semibold text-ink">{pkg.name}</p>
+                {pkg.basePriceCents != null && (
+                  <span className="flex-none text-sm tabular-nums text-ink">
+                    {formatPrice(pkg.basePriceCents)}
+                  </span>
+                )}
+              </div>
               {resolvedModifiers.length > 0 && (
                 <ul className="mt-2 space-y-1">
                   {resolvedModifiers.map((m) => {
                     const displayVal = modifierDisplayValue(m, modifierValues);
+                    const delta = computeModifierDelta(m, modifierValues);
                     return (
                       <li key={m.id} className="flex items-baseline justify-between gap-3 text-sm">
                         <span className="text-ink-muted">
@@ -309,9 +317,10 @@ export const BookingForm = ({
                             <span className="ml-1 text-xs text-ink-faint">(included)</span>
                           )}
                         </span>
-                        {m.priceDeltaCents != null && !m.isRequired && (
+                        {delta !== 0 && (
                           <span className="flex-none text-xs tabular-nums text-ink-faint">
-                            +{formatPrice(m.priceDeltaCents)}
+                            {delta > 0 ? '+' : ''}
+                            {formatPrice(delta)}
                           </span>
                         )}
                       </li>
@@ -322,11 +331,14 @@ export const BookingForm = ({
               {estimatedTotalCents != null && (
                 <div className="mt-3 border-t border-border pt-3">
                   {discountActive && (
-                    <div className="mb-2 flex items-center gap-1.5 rounded-card border border-accent/20 bg-accent/5 px-2.5 py-1.5">
-                      <span className="font-mono text-[9px] font-bold uppercase tracking-widest text-accent/80">
-                        {SALE.name}
+                    <div className="mb-2 flex items-center justify-between">
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-xs tracking-widest text-accent">{SALE.name}</span>
+                        <span className="text-xs text-accent">{SALE.discountLabel}</span>
+                      </div>
+                      <span className="flex-none text-xs tabular-nums text-accent">
+                        −{formatPrice(estimatedTotalCents - applyDiscount(estimatedTotalCents))}
                       </span>
-                      <span className="text-xs text-accent">{SALE.discountLabel}</span>
                     </div>
                   )}
                   {saleAnnouncementActive && preferredDate && !discountActive && (
@@ -624,7 +636,14 @@ const SummaryPanel = ({
       <p className="mb-1 text-xs font-medium uppercase tracking-widest text-ink-faint">
         Your selection
       </p>
-      <p className="text-base font-semibold text-ink">{pkg.name}</p>
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="text-base font-semibold text-ink">{pkg.name}</p>
+        {pkg.basePriceCents != null && (
+          <span className="flex-none text-sm tabular-nums text-ink">
+            {formatPrice(pkg.basePriceCents)}
+          </span>
+        )}
+      </div>
       {pkg.description && (
         <p className="mt-1 text-sm leading-relaxed text-ink-muted">{pkg.description}</p>
       )}

--- a/apps/evrydayarchive-web/app/book/booking-form.tsx
+++ b/apps/evrydayarchive-web/app/book/booking-form.tsx
@@ -16,7 +16,7 @@ import { LocationPicker } from '../components/location-picker';
 import type { CoreLocation } from '../components/location-picker';
 import { DatePicker } from './date-picker';
 import { TimePicker } from './time-picker';
-import { SALE } from '../lib/sale';
+import { SALE, applyDiscount, isSaleDate } from '../lib/sale';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -25,8 +25,8 @@ type Props = {
   resolvedModifiers: PublicPackageModifier[];
   modifierValues: Record<string, number>;
   estimatedTotalCents: number | undefined;
-  /** Defined during May 2026 only — 10% April Sale discount applied. */
-  discountedTotalCents: number | undefined;
+  /** True when the user opted into the Spring Sale in the package builder (sale=1 param). */
+  springSale: boolean;
   timeSlots: TimeSlot[];
   locationWindows: LocationWindow[];
 };
@@ -47,6 +47,25 @@ const modifierDisplayValue = (
     return `${v}${cfg.unit ? ` ${cfg.unit}` : ''}`;
   }
   return null;
+};
+
+// Computes the price delta for a single modifier given current slider/incrementer values.
+// Mirrors the same helper in book/page.tsx (used server-side for the estimated total).
+const computeModifierDelta = (m: PublicPackageModifier, values: Record<string, number>): number => {
+  if (m.type === 'SLIDER') {
+    const cfg = m.config as SliderConfig | null;
+    if (!cfg) return 0;
+    const value = values[m.id] ?? cfg.defaultValue;
+    const steps = Math.round((value - cfg.defaultValue) / cfg.step);
+    return steps * cfg.pricePerStep;
+  }
+  if (m.type === 'INCREMENTER') {
+    const cfg = m.config as IncrementerConfig | null;
+    if (!cfg) return 0;
+    const count = values[m.id] ?? cfg.defaultValue;
+    return (count - cfg.defaultValue) * cfg.pricePerUnit;
+  }
+  return m.priceDeltaCents ?? 0;
 };
 
 type FormStatus = 'idle' | 'submitting' | 'success' | 'error';
@@ -120,7 +139,7 @@ export const BookingForm = ({
   resolvedModifiers,
   modifierValues,
   estimatedTotalCents,
-  discountedTotalCents,
+  springSale,
   timeSlots,
   locationWindows
 }: Props) => {
@@ -146,6 +165,13 @@ export const BookingForm = ({
   const locationOtherRef = useRef<HTMLInputElement>(null);
 
   const today = new Date().toISOString().split('T')[0] as string;
+
+  // Spring Sale: active when the user opted in AND has selected (or not yet chosen) a May date.
+  // Becomes false as soon as they pick a non-May date, removing it from pricing.
+  const discountActive = springSale && (!preferredDate || isSaleDate(preferredDate));
+  const discountedTotalCents =
+    discountActive && estimatedTotalCents != null ? applyDiscount(estimatedTotalCents) : undefined;
+  const effectiveTotalCents = discountedTotalCents ?? estimatedTotalCents;
 
   // ── Derived location value ──────────────────────────────────────────────────
 
@@ -222,9 +248,9 @@ export const BookingForm = ({
       packageName: pkg?.name,
       modifierIds: resolvedModifiers.filter((m) => !m.isRequired).map((m) => m.id),
       modifierValues: Object.keys(modifierValues).length > 0 ? modifierValues : undefined,
-      // Use the discounted total when the April Sale applies, so the booking record
-      // reflects what the customer was actually quoted.
-      estimatedTotalCents: discountedTotalCents ?? estimatedTotalCents
+      // Reflects the discounted total when Spring Sale is active so the booking record
+      // shows what the customer was actually quoted.
+      estimatedTotalCents: effectiveTotalCents
     };
 
     try {
@@ -255,278 +281,411 @@ export const BookingForm = ({
   }
 
   return (
-    <form onSubmit={handleSubmit} noValidate className="space-y-10">
-      {/* Mobile-only package summary — desktop has a sidebar */}
-      {pkg && (
-        <div className="rounded-card border border-border bg-sun px-5 py-5 lg:hidden">
-          <p className="mb-1 text-xs font-medium uppercase tracking-widest text-ink-faint">
-            Your selection
-          </p>
-          <p className="text-base font-semibold text-ink">{pkg.name}</p>
-          {resolvedModifiers.length > 0 && (
-            <ul className="mt-2 space-y-1">
-              {resolvedModifiers.map((m) => {
-                const displayVal = modifierDisplayValue(m, modifierValues);
-                return (
-                  <li key={m.id} className="flex items-baseline justify-between gap-3 text-sm">
-                    <span className="text-ink-muted">
-                      {m.name}
-                      {displayVal && (
-                        <span className="ml-1 text-xs text-ink-faint">({displayVal})</span>
-                      )}
-                      {m.isRequired && !displayVal && (
-                        <span className="ml-1 text-xs text-ink-faint">(included)</span>
-                      )}
-                    </span>
-                    {m.priceDeltaCents != null && !m.isRequired && (
-                      <span className="flex-none text-xs tabular-nums text-ink-faint">
-                        +{formatPrice(m.priceDeltaCents)}
+    <>
+      <div className="min-w-0 flex-1">
+        <form onSubmit={handleSubmit} noValidate className="space-y-10">
+          {/* Mobile-only package summary — desktop has a sidebar */}
+          {pkg && (
+            <div className="rounded-card border border-border bg-sun px-5 py-5 lg:hidden">
+              <p className="mb-1 text-xs font-medium uppercase tracking-widest text-ink-faint">
+                Your selection
+              </p>
+              <p className="text-base font-semibold text-ink">{pkg.name}</p>
+              {resolvedModifiers.length > 0 && (
+                <ul className="mt-2 space-y-1">
+                  {resolvedModifiers.map((m) => {
+                    const displayVal = modifierDisplayValue(m, modifierValues);
+                    return (
+                      <li key={m.id} className="flex items-baseline justify-between gap-3 text-sm">
+                        <span className="text-ink-muted">
+                          {m.name}
+                          {displayVal && (
+                            <span className="ml-1 text-xs text-ink-faint">({displayVal})</span>
+                          )}
+                          {m.isRequired && !displayVal && (
+                            <span className="ml-1 text-xs text-ink-faint">(included)</span>
+                          )}
+                        </span>
+                        {m.priceDeltaCents != null && !m.isRequired && (
+                          <span className="flex-none text-xs tabular-nums text-ink-faint">
+                            +{formatPrice(m.priceDeltaCents)}
+                          </span>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+              {estimatedTotalCents != null && (
+                <div className="mt-3 border-t border-border pt-3">
+                  {discountActive && (
+                    <div className="mb-2 flex items-center gap-1.5 rounded-card border border-accent/20 bg-accent/5 px-2.5 py-1.5">
+                      <span className="font-mono text-[9px] font-bold uppercase tracking-widest text-accent/80">
+                        {SALE.name}
                       </span>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-          {estimatedTotalCents != null && (
-            <div className="mt-3 border-t border-border pt-3">
-              {discountedTotalCents != null && (
-                <div className="mb-2 flex items-center gap-1.5 rounded-card border border-accent/20 bg-accent/5 px-2.5 py-1.5">
-                  <span className="font-mono text-[9px] font-bold uppercase tracking-widest text-accent/80">
-                    {SALE.name}
-                  </span>
-                  <span className="text-xs text-accent">{SALE.discountLabel}</span>
+                      <span className="text-xs text-accent">{SALE.discountLabel}</span>
+                    </div>
+                  )}
+                  {springSale && preferredDate && !discountActive && (
+                    <p className="mb-2 text-xs text-ink-faint">
+                      Spring Sale applies to May sessions only.
+                    </p>
+                  )}
+                  <div className="flex items-baseline justify-between">
+                    <span className="text-xs text-ink-faint">Estimated total</span>
+                    <div className="flex items-baseline gap-2">
+                      {discountedTotalCents != null && (
+                        <span className="text-xs tabular-nums text-ink-faint line-through">
+                          {formatPrice(estimatedTotalCents)}
+                        </span>
+                      )}
+                      <span className="text-sm font-semibold text-ink">
+                        {formatPrice(effectiveTotalCents ?? estimatedTotalCents)}
+                      </span>
+                    </div>
+                  </div>
                 </div>
               )}
-              <div className="flex items-baseline justify-between">
-                <span className="text-xs text-ink-faint">Estimated total</span>
-                <div className="flex items-baseline gap-2">
-                  {discountedTotalCents != null && (
-                    <span className="text-xs tabular-nums text-ink-faint line-through">
-                      {formatPrice(estimatedTotalCents)}
-                    </span>
-                  )}
-                  <span className="text-sm font-semibold text-ink">
-                    {formatPrice(discountedTotalCents ?? estimatedTotalCents)}
-                  </span>
-                </div>
-              </div>
             </div>
           )}
-        </div>
-      )}
 
-      {/* Location */}
-      <fieldset className="space-y-5">
-        <legend className="text-sm font-semibold text-ink">Where are you based?</legend>
-        <p className="text-xs leading-relaxed text-ink-faint">
-          I travel regularly between Vancouver Island and the mainland. Let me know which area
-          you&apos;re in so I can confirm I&apos;ll be there.
-        </p>
+          {/* Location */}
+          <fieldset className="space-y-5">
+            <legend className="text-sm font-semibold text-ink">Where are you based?</legend>
+            <p className="text-xs leading-relaxed text-ink-faint">
+              I travel regularly between Vancouver Island and the mainland. Let me know which area
+              you&apos;re in so I can confirm I&apos;ll be there.
+            </p>
 
-        <div className="flex flex-col gap-1.5">
-          <label htmlFor="location-select" className="text-sm font-medium text-ink-muted">
-            Location{' '}
-            <span className="text-accent" aria-hidden="true">
-              *
-            </span>
-          </label>
-          <LocationPicker
-            id="location-select"
-            value={locationSelect}
-            onChange={(v) => {
-              setLocationSelect(v);
-              setLocationOther('');
-              clearError('location');
-            }}
-            hasError={!!fieldErrors.location && locationSelect !== 'Other'}
-            aria-describedby={
-              fieldErrors.location && locationSelect !== 'Other' ? 'location-error' : undefined
-            }
-          />
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor="location-select" className="text-sm font-medium text-ink-muted">
+                Location{' '}
+                <span className="text-accent" aria-hidden="true">
+                  *
+                </span>
+              </label>
+              <LocationPicker
+                id="location-select"
+                value={locationSelect}
+                onChange={(v) => {
+                  setLocationSelect(v);
+                  setLocationOther('');
+                  clearError('location');
+                }}
+                hasError={!!fieldErrors.location && locationSelect !== 'Other'}
+                aria-describedby={
+                  fieldErrors.location && locationSelect !== 'Other' ? 'location-error' : undefined
+                }
+              />
 
-          {locationSelect === 'Other' && (
-            <input
-              ref={locationOtherRef}
-              id="location-other"
-              type="text"
-              placeholder="e.g. Tofino, Whistler, Victoria area…"
-              value={locationOther}
-              onChange={(e) => {
-                setLocationOther(e.target.value);
-                clearError('location');
-              }}
-              aria-label="Describe your location"
-              aria-invalid={!!fieldErrors.location}
-              aria-describedby={fieldErrors.location ? 'location-error' : undefined}
-              className={inputCls(!!fieldErrors.location)}
+              {locationSelect === 'Other' && (
+                <input
+                  ref={locationOtherRef}
+                  id="location-other"
+                  type="text"
+                  placeholder="e.g. Tofino, Whistler, Victoria area…"
+                  value={locationOther}
+                  onChange={(e) => {
+                    setLocationOther(e.target.value);
+                    clearError('location');
+                  }}
+                  aria-label="Describe your location"
+                  aria-invalid={!!fieldErrors.location}
+                  aria-describedby={fieldErrors.location ? 'location-error' : undefined}
+                  className={inputCls(!!fieldErrors.location)}
+                />
+              )}
+
+              <FieldError id="location-error" message={fieldErrors.location} />
+            </div>
+          </fieldset>
+
+          {/* Date + time */}
+          <fieldset className="space-y-5">
+            <legend className="text-sm font-semibold text-ink">Preferred date &amp; time</legend>
+            <p className="text-xs leading-relaxed text-ink-faint">
+              This is a preference, not a confirmed slot. I&apos;ll reach out to confirm
+              availability. Dates shown in red are unavailable.
+            </p>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="preferred-date" className="text-sm font-medium text-ink-muted">
+                  Date{' '}
+                  <span className="text-accent" aria-hidden="true">
+                    *
+                  </span>
+                </label>
+                <DatePicker
+                  id="preferred-date"
+                  value={preferredDate}
+                  onChange={(v) => {
+                    setPreferredDate(v);
+                    clearError('date');
+                  }}
+                  min={today}
+                  unavailableDates={unavailableDates}
+                  locationWindows={locationWindows}
+                  placeholder="Choose a date"
+                  hasError={!!fieldErrors.date}
+                  aria-describedby={fieldErrors.date ? 'date-error' : undefined}
+                />
+                <FieldError id="date-error" message={fieldErrors.date} />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="preferred-time" className="text-sm font-medium text-ink-muted">
+                  Preferred time{' '}
+                  <span className="text-xs font-normal text-ink-faint">(optional)</span>
+                </label>
+                <TimePicker id="preferred-time" value={preferredTime} onChange={setPreferredTime} />
+              </div>
+            </div>
+          </fieldset>
+
+          {/* Contact details */}
+          <fieldset className="space-y-5">
+            <legend className="text-sm font-semibold text-ink">Your details</legend>
+
+            {/* Name */}
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor="name" className="text-sm font-medium text-ink-muted">
+                Full name{' '}
+                <span className="text-accent" aria-hidden="true">
+                  *
+                </span>
+              </label>
+              <input
+                ref={nameRef}
+                id="name"
+                type="text"
+                autoComplete="name"
+                placeholder="Jane Smith"
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value);
+                  clearError('name');
+                }}
+                aria-invalid={!!fieldErrors.name}
+                aria-describedby={fieldErrors.name ? 'name-error' : undefined}
+                className={inputCls(!!fieldErrors.name)}
+              />
+              <FieldError id="name-error" message={fieldErrors.name} />
+            </div>
+
+            {/* Email */}
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor="email" className="text-sm font-medium text-ink-muted">
+                Email{' '}
+                <span className="text-accent" aria-hidden="true">
+                  *
+                </span>
+              </label>
+              <input
+                ref={emailRef}
+                id="email"
+                type="email"
+                autoComplete="email"
+                placeholder="you@example.com"
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  clearError('email');
+                }}
+                aria-invalid={!!fieldErrors.email}
+                aria-describedby={fieldErrors.email ? 'email-error' : undefined}
+                className={inputCls(!!fieldErrors.email)}
+              />
+              <FieldError id="email-error" message={fieldErrors.email} />
+            </div>
+
+            {/* Phone */}
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor="phone" className="text-sm font-medium text-ink-muted">
+                Phone <span className="text-xs font-normal text-ink-faint">(optional)</span>
+              </label>
+              <input
+                ref={phoneRef}
+                id="phone"
+                type="tel"
+                autoComplete="tel"
+                placeholder="+1 (613) 555-0100"
+                value={phone}
+                onChange={(e) => {
+                  setPhone(e.target.value);
+                  clearError('phone');
+                }}
+                aria-invalid={!!fieldErrors.phone}
+                aria-describedby={fieldErrors.phone ? 'phone-error' : undefined}
+                className={inputCls(!!fieldErrors.phone)}
+              />
+              <FieldError id="phone-error" message={fieldErrors.phone} />
+            </div>
+          </fieldset>
+
+          {/* Notes */}
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="notes" className="text-sm font-medium text-ink-muted">
+              Anything else I should know?{' '}
+              <span className="text-xs font-normal text-ink-faint">(optional)</span>
+            </label>
+            <textarea
+              id="notes"
+              rows={4}
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Vision, vibe, special requests…"
+              className={`${inputCls()} resize-none`}
             />
+          </div>
+
+          {/* Server error */}
+          {status === 'error' && (
+            <p
+              role="alert"
+              className="rounded-card border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+            >
+              {serverError}
+            </p>
           )}
 
-          <FieldError id="location-error" message={fieldErrors.location} />
-        </div>
-      </fieldset>
-
-      {/* Date + time */}
-      <fieldset className="space-y-5">
-        <legend className="text-sm font-semibold text-ink">Preferred date &amp; time</legend>
-        <p className="text-xs leading-relaxed text-ink-faint">
-          This is a preference, not a confirmed slot. I&apos;ll reach out to confirm availability.
-          Dates shown in red are unavailable.
-        </p>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="preferred-date" className="text-sm font-medium text-ink-muted">
-              Date{' '}
-              <span className="text-accent" aria-hidden="true">
-                *
-              </span>
-            </label>
-            <DatePicker
-              id="preferred-date"
-              value={preferredDate}
-              onChange={(v) => {
-                setPreferredDate(v);
-                clearError('date');
-              }}
-              min={today}
-              unavailableDates={unavailableDates}
-              locationWindows={locationWindows}
-              placeholder="Choose a date"
-              hasError={!!fieldErrors.date}
-              aria-describedby={fieldErrors.date ? 'date-error' : undefined}
-            />
-            <FieldError id="date-error" message={fieldErrors.date} />
+          {/* Submit */}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <button
+              type="submit"
+              disabled={status === 'submitting'}
+              className="rounded-card bg-accent px-8 py-3.5 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            >
+              {status === 'submitting' ? 'Sending…' : 'Send request'}
+            </button>
+            <p className="text-xs leading-relaxed text-ink-faint">
+              No commitment. I&apos;ll be in touch soon.
+            </p>
           </div>
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="preferred-time" className="text-sm font-medium text-ink-muted">
-              Preferred time <span className="text-xs font-normal text-ink-faint">(optional)</span>
-            </label>
-            <TimePicker id="preferred-time" value={preferredTime} onChange={setPreferredTime} />
-          </div>
-        </div>
-      </fieldset>
-
-      {/* Contact details */}
-      <fieldset className="space-y-5">
-        <legend className="text-sm font-semibold text-ink">Your details</legend>
-
-        {/* Name */}
-        <div className="flex flex-col gap-1.5">
-          <label htmlFor="name" className="text-sm font-medium text-ink-muted">
-            Full name{' '}
-            <span className="text-accent" aria-hidden="true">
-              *
-            </span>
-          </label>
-          <input
-            ref={nameRef}
-            id="name"
-            type="text"
-            autoComplete="name"
-            placeholder="Jane Smith"
-            value={name}
-            onChange={(e) => {
-              setName(e.target.value);
-              clearError('name');
-            }}
-            aria-invalid={!!fieldErrors.name}
-            aria-describedby={fieldErrors.name ? 'name-error' : undefined}
-            className={inputCls(!!fieldErrors.name)}
-          />
-          <FieldError id="name-error" message={fieldErrors.name} />
-        </div>
-
-        {/* Email */}
-        <div className="flex flex-col gap-1.5">
-          <label htmlFor="email" className="text-sm font-medium text-ink-muted">
-            Email{' '}
-            <span className="text-accent" aria-hidden="true">
-              *
-            </span>
-          </label>
-          <input
-            ref={emailRef}
-            id="email"
-            type="email"
-            autoComplete="email"
-            placeholder="you@example.com"
-            value={email}
-            onChange={(e) => {
-              setEmail(e.target.value);
-              clearError('email');
-            }}
-            aria-invalid={!!fieldErrors.email}
-            aria-describedby={fieldErrors.email ? 'email-error' : undefined}
-            className={inputCls(!!fieldErrors.email)}
-          />
-          <FieldError id="email-error" message={fieldErrors.email} />
-        </div>
-
-        {/* Phone */}
-        <div className="flex flex-col gap-1.5">
-          <label htmlFor="phone" className="text-sm font-medium text-ink-muted">
-            Phone <span className="text-xs font-normal text-ink-faint">(optional)</span>
-          </label>
-          <input
-            ref={phoneRef}
-            id="phone"
-            type="tel"
-            autoComplete="tel"
-            placeholder="+1 (613) 555-0100"
-            value={phone}
-            onChange={(e) => {
-              setPhone(e.target.value);
-              clearError('phone');
-            }}
-            aria-invalid={!!fieldErrors.phone}
-            aria-describedby={fieldErrors.phone ? 'phone-error' : undefined}
-            className={inputCls(!!fieldErrors.phone)}
-          />
-          <FieldError id="phone-error" message={fieldErrors.phone} />
-        </div>
-      </fieldset>
-
-      {/* Notes */}
-      <div className="flex flex-col gap-1.5">
-        <label htmlFor="notes" className="text-sm font-medium text-ink-muted">
-          Anything else I should know?{' '}
-          <span className="text-xs font-normal text-ink-faint">(optional)</span>
-        </label>
-        <textarea
-          id="notes"
-          rows={4}
-          value={notes}
-          onChange={(e) => setNotes(e.target.value)}
-          placeholder="Vision, vibe, special requests…"
-          className={`${inputCls()} resize-none`}
-        />
+        </form>
       </div>
 
-      {/* Server error */}
-      {status === 'error' && (
-        <p
-          role="alert"
-          className="rounded-card border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
-        >
-          {serverError}
-        </p>
+      {pkg && (
+        <aside className="hidden lg:block lg:w-80 lg:flex-none lg:sticky lg:top-8">
+          <SummaryPanel
+            pkg={pkg}
+            resolvedModifiers={resolvedModifiers}
+            modifierValues={modifierValues}
+            estimatedTotalCents={estimatedTotalCents}
+            discountActive={discountActive}
+            springSale={springSale}
+            hasDate={!!preferredDate}
+          />
+          <div className="mt-6 px-1">
+            <p className="mb-2 text-xs font-medium uppercase tracking-widest text-ink-faint">
+              What happens next
+            </p>
+            <p className="text-sm leading-relaxed text-ink-muted">
+              Once you submit, I&apos;ll review your request and be in touch to confirm the date and
+              sort out any details.
+            </p>
+          </div>
+        </aside>
+      )}
+    </>
+  );
+};
+
+// ── Desktop summary sidebar ───────────────────────────────────────────────────
+
+type SummaryPanelProps = {
+  pkg: PublicPackage;
+  resolvedModifiers: PublicPackageModifier[];
+  modifierValues: Record<string, number>;
+  estimatedTotalCents: number | undefined;
+  discountActive: boolean;
+  springSale: boolean;
+  hasDate: boolean;
+};
+
+const SummaryPanel = ({
+  pkg,
+  resolvedModifiers,
+  modifierValues,
+  estimatedTotalCents,
+  discountActive,
+  springSale,
+  hasDate
+}: SummaryPanelProps) => {
+  const discountedTotal =
+    discountActive && estimatedTotalCents != null ? applyDiscount(estimatedTotalCents) : undefined;
+  const effectiveTotal = discountedTotal ?? estimatedTotalCents;
+
+  return (
+    <div className="rounded-card border border-border bg-sun px-5 py-6">
+      <p className="mb-1 text-xs font-medium uppercase tracking-widest text-ink-faint">
+        Your selection
+      </p>
+      <p className="text-base font-semibold text-ink">{pkg.name}</p>
+      {pkg.description && (
+        <p className="mt-1 text-sm leading-relaxed text-ink-muted">{pkg.description}</p>
       )}
 
-      {/* Submit */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-        <button
-          type="submit"
-          disabled={status === 'submitting'}
-          className="rounded-card bg-accent px-8 py-3.5 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
-        >
-          {status === 'submitting' ? 'Sending…' : 'Send request'}
-        </button>
-        <p className="text-xs leading-relaxed text-ink-faint">
-          No commitment. I&apos;ll be in touch soon.
-        </p>
-      </div>
-    </form>
+      {resolvedModifiers.length > 0 && (
+        <ul className="mt-4 space-y-2 border-t border-border pt-4">
+          {resolvedModifiers.map((m) => {
+            const displayVal = modifierDisplayValue(m, modifierValues);
+            const delta = computeModifierDelta(m, modifierValues);
+            return (
+              <li key={m.id} className="flex items-baseline justify-between gap-3 text-sm">
+                <span className="text-ink-muted">
+                  {m.name}
+                  {displayVal && (
+                    <span className="ml-1 text-xs text-ink-faint">({displayVal})</span>
+                  )}
+                  {m.isRequired && !displayVal && (
+                    <span className="ml-1 text-xs text-ink-faint">(included)</span>
+                  )}
+                </span>
+                {delta !== 0 && (
+                  <span className="flex-none text-xs tabular-nums text-ink-faint">
+                    {delta > 0 ? '+' : ''}
+                    {formatPrice(delta)}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {estimatedTotalCents != null && (
+        <div className="mt-4 space-y-2 border-t border-border pt-4">
+          {discountActive && (
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-1.5">
+                <span className="font-mono text-[9px] font-bold uppercase tracking-widest text-accent/80">
+                  {SALE.name}
+                </span>
+                <span className="text-xs text-accent">{SALE.discountLabel}</span>
+              </div>
+              <span className="flex-none text-xs tabular-nums text-accent">
+                −{formatPrice(estimatedTotalCents - applyDiscount(estimatedTotalCents))}
+              </span>
+            </div>
+          )}
+          {springSale && hasDate && !discountActive && (
+            <p className="text-xs text-ink-faint">Spring Sale applies to May sessions only.</p>
+          )}
+          <div className="flex items-baseline justify-between">
+            <span className="text-xs text-ink-faint">Estimated total</span>
+            <div className="flex items-baseline gap-2">
+              {discountedTotal != null && (
+                <span className="text-xs tabular-nums text-ink-faint line-through">
+                  {formatPrice(estimatedTotalCents)}
+                </span>
+              )}
+              <span className="text-sm font-semibold text-ink">
+                {formatPrice(effectiveTotal ?? estimatedTotalCents)}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/apps/evrydayarchive-web/app/book/booking-form.tsx
+++ b/apps/evrydayarchive-web/app/book/booking-form.tsx
@@ -16,7 +16,7 @@ import { LocationPicker } from '../components/location-picker';
 import type { CoreLocation } from '../components/location-picker';
 import { DatePicker } from './date-picker';
 import { TimePicker } from './time-picker';
-import { SALE, applyDiscount, isSaleDate } from '../lib/sale';
+import { SALE, applyDiscount, isSaleAnnouncementActive, isSaleDate } from '../lib/sale';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -166,9 +166,12 @@ export const BookingForm = ({
 
   const today = new Date().toISOString().split('T')[0] as string;
 
-  // Spring Sale: active when the user opted in AND has selected (or not yet chosen) a May date.
-  // Becomes false as soon as they pick a non-May date, removing it from pricing.
-  const discountActive = springSale && (!preferredDate || isSaleDate(preferredDate));
+  // Spring Sale: active whenever the sale is running and a May date is selected.
+  // If the user came from the builder with sale=1 and hasn't picked a date yet, treat as pending
+  // (discount shown) — it clears as soon as they pick a non-May date.
+  const saleAnnouncementActive = isSaleAnnouncementActive();
+  const discountActive =
+    saleAnnouncementActive && ((springSale && !preferredDate) || isSaleDate(preferredDate));
   const discountedTotalCents =
     discountActive && estimatedTotalCents != null ? applyDiscount(estimatedTotalCents) : undefined;
   const effectiveTotalCents = discountedTotalCents ?? estimatedTotalCents;
@@ -326,7 +329,7 @@ export const BookingForm = ({
                       <span className="text-xs text-accent">{SALE.discountLabel}</span>
                     </div>
                   )}
-                  {springSale && preferredDate && !discountActive && (
+                  {saleAnnouncementActive && preferredDate && !discountActive && (
                     <p className="mb-2 text-xs text-ink-faint">
                       Spring Sale applies to May sessions only.
                     </p>
@@ -428,6 +431,11 @@ export const BookingForm = ({
                   placeholder="Choose a date"
                   hasError={!!fieldErrors.date}
                   aria-describedby={fieldErrors.date ? 'date-error' : undefined}
+                  saleMonth={
+                    saleAnnouncementActive
+                      ? { year: SALE.discountYear, month: SALE.discountMonth }
+                      : undefined
+                  }
                 />
                 <FieldError id="date-error" message={fieldErrors.date} />
               </div>
@@ -571,7 +579,6 @@ export const BookingForm = ({
             modifierValues={modifierValues}
             estimatedTotalCents={estimatedTotalCents}
             discountActive={discountActive}
-            springSale={springSale}
             hasDate={!!preferredDate}
           />
           <div className="mt-6 px-1">
@@ -597,7 +604,6 @@ type SummaryPanelProps = {
   modifierValues: Record<string, number>;
   estimatedTotalCents: number | undefined;
   discountActive: boolean;
-  springSale: boolean;
   hasDate: boolean;
 };
 
@@ -607,7 +613,6 @@ const SummaryPanel = ({
   modifierValues,
   estimatedTotalCents,
   discountActive,
-  springSale,
   hasDate
 }: SummaryPanelProps) => {
   const discountedTotal =
@@ -667,7 +672,7 @@ const SummaryPanel = ({
               </span>
             </div>
           )}
-          {springSale && hasDate && !discountActive && (
+          {isSaleAnnouncementActive() && hasDate && !discountActive && (
             <p className="text-xs text-ink-faint">Spring Sale applies to May sessions only.</p>
           )}
           <div className="flex items-baseline justify-between">

--- a/apps/evrydayarchive-web/app/book/date-picker.tsx
+++ b/apps/evrydayarchive-web/app/book/date-picker.tsx
@@ -34,6 +34,8 @@ type Props = {
   placeholder?: string;
   hasError?: boolean;
   'aria-describedby'?: string;
+  /** When set, all days in this month are highlighted with a sale tint. */
+  saleMonth?: { year: number; month: number }; // month is 0-indexed
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -58,7 +60,8 @@ export const DatePicker = ({
   locationWindows,
   placeholder = 'Select a date',
   hasError = false,
-  'aria-describedby': ariaDescribedby
+  'aria-describedby': ariaDescribedby,
+  saleMonth
 }: Props) => {
   const today = new Date();
 
@@ -137,6 +140,9 @@ export const DatePicker = ({
 
   const isToday = (day: number) =>
     today.getFullYear() === viewYear && today.getMonth() === viewMonth && today.getDate() === day;
+
+  // True when the currently-viewed month is the sale month (all days get an orange tint)
+  const isSaleMonth = !!saleMonth && viewYear === saleMonth.year && viewMonth === saleMonth.month;
 
   // ── Schedule panel ───────────────────────────────────────────────────────
 
@@ -341,9 +347,13 @@ export const DatePicker = ({
                               ? 'cursor-not-allowed text-ink-faint opacity-30'
                               : unavailable
                                 ? 'cursor-not-allowed bg-red-100 text-red-500 dark:bg-red-950/40 dark:text-red-500'
-                                : todayCell
-                                  ? 'font-medium text-ink ring-1 ring-inset ring-border hover:bg-sun'
-                                  : 'text-ink-muted hover:bg-sun hover:text-ink'
+                                : isSaleMonth && todayCell
+                                  ? 'font-medium bg-accent/10 text-accent ring-1 ring-inset ring-accent/30 hover:bg-accent/20'
+                                  : isSaleMonth
+                                    ? 'bg-accent/10 text-accent hover:bg-accent/20'
+                                    : todayCell
+                                      ? 'font-medium text-ink ring-1 ring-inset ring-border hover:bg-sun'
+                                      : 'text-ink-muted hover:bg-sun hover:text-ink'
                         ].join(' ')}
                       >
                         {day}
@@ -361,6 +371,14 @@ export const DatePicker = ({
                   </span>
                   Unavailable
                 </span>
+                {isSaleMonth && (
+                  <span className="flex items-center gap-1.5 text-[10px] text-ink-faint">
+                    <span className="inline-flex h-4 w-4 items-center justify-center rounded bg-accent/10 text-[9px] text-accent">
+                      ✦
+                    </span>
+                    Spring Sale
+                  </span>
+                )}
               </div>
             </div>
           </div>

--- a/apps/evrydayarchive-web/app/book/page.tsx
+++ b/apps/evrydayarchive-web/app/book/page.tsx
@@ -13,7 +13,7 @@ import {
 } from '@repo/core';
 
 import { getServerEnv } from '../lib/env';
-import { isSaleAnnouncementActive } from '../lib/sale';
+import { isSaleAnnouncementActive, isSaleAutoOptIn } from '../lib/sale';
 import { BookingForm } from './booking-form';
 
 export const dynamic = 'force-dynamic';
@@ -124,9 +124,9 @@ export default async function BookPage({ searchParams }: Props) {
         }, 0)
       : undefined;
 
-  // Spring Sale: opt-in via the package builder (sale=1 param).
-  // Date validation (must be a May date) happens client-side in BookingForm.
-  const springSale = sale === '1' && isSaleAnnouncementActive();
+  // Spring Sale: opt-in via the package builder (sale=1 param), or auto-enabled during
+  // April and May. Date validation (must be a May date) happens client-side in BookingForm.
+  const springSale = (sale === '1' || isSaleAutoOptIn()) && isSaleAnnouncementActive();
 
   const backHref =
     from === 'packages' || !pkg ? '/packages' : `/package-builder?package=${pkg.slug}`;

--- a/apps/evrydayarchive-web/app/book/page.tsx
+++ b/apps/evrydayarchive-web/app/book/page.tsx
@@ -13,6 +13,7 @@ import {
 } from '@repo/core';
 
 import { getServerEnv } from '../lib/env';
+import { isSaleDiscountActive, applyDiscount, SALE } from '../lib/sale';
 import { BookingForm } from './booking-form';
 
 export const dynamic = 'force-dynamic';
@@ -128,6 +129,11 @@ export default async function BookPage({ searchParams }: Props) {
         }, 0)
       : undefined;
 
+  // During May 2026, booking requests get 10% off automatically.
+  const discountActive = isSaleDiscountActive();
+  const discountedTotalCents =
+    discountActive && estimatedTotalCents != null ? applyDiscount(estimatedTotalCents) : undefined;
+
   const backHref =
     from === 'packages' || !pkg ? '/packages' : `/package-builder?package=${pkg.slug}`;
   const backLabel = from === 'packages' || !pkg ? '← Back to packages' : '← Back to builder';
@@ -168,6 +174,7 @@ export default async function BookPage({ searchParams }: Props) {
               resolvedModifiers={resolvedModifiers}
               modifierValues={modifierValues}
               estimatedTotalCents={estimatedTotalCents}
+              discountedTotalCents={discountedTotalCents}
               timeSlots={timeSlots}
               locationWindows={locationWindows}
             />
@@ -181,6 +188,7 @@ export default async function BookPage({ searchParams }: Props) {
                 resolvedModifiers={resolvedModifiers}
                 modifierValues={modifierValues}
                 estimatedTotalCents={estimatedTotalCents}
+                discountedTotalCents={discountedTotalCents}
               />
               <div className="mt-6 px-1">
                 <p className="mb-2 text-xs font-medium uppercase tracking-widest text-ink-faint">
@@ -206,6 +214,7 @@ type SummaryPanelProps = {
   resolvedModifiers: PublicPackageModifier[];
   modifierValues: Record<string, number>;
   estimatedTotalCents: number | undefined;
+  discountedTotalCents: number | undefined;
 };
 
 const modifierDisplayValue = (
@@ -231,7 +240,8 @@ const SummaryPanel = ({
   pkg,
   resolvedModifiers,
   modifierValues,
-  estimatedTotalCents
+  estimatedTotalCents,
+  discountedTotalCents
 }: SummaryPanelProps) => (
   <div className="rounded-card border border-border bg-sun px-6 py-6 shadow-warm-sm">
     <p className="mb-4 text-xs font-medium uppercase tracking-widest text-ink-faint">
@@ -282,9 +292,30 @@ const SummaryPanel = ({
     {/* Estimated total */}
     {estimatedTotalCents != null && (
       <>
+        {discountedTotalCents != null && (
+          <div className="mb-3 flex items-center gap-2 rounded-card border border-accent/20 bg-accent/5 px-3 py-2">
+            <span className="font-mono text-[9px] font-bold uppercase tracking-widest text-accent/80">
+              {SALE.name}
+            </span>
+            <span className="text-xs text-accent">{SALE.discountLabel} applied</span>
+          </div>
+        )}
         <div className="flex items-baseline justify-between">
           <span className="text-sm font-medium text-ink-muted">Estimated total</span>
-          <span className="text-xl font-semibold text-ink">{formatPrice(estimatedTotalCents)}</span>
+          {discountedTotalCents != null ? (
+            <div className="flex flex-col items-end gap-0.5">
+              <span className="text-xs tabular-nums text-ink-faint line-through">
+                {formatPrice(estimatedTotalCents)}
+              </span>
+              <span className="text-xl font-semibold text-ink">
+                {formatPrice(discountedTotalCents)}
+              </span>
+            </div>
+          ) : (
+            <span className="text-xl font-semibold text-ink">
+              {formatPrice(estimatedTotalCents)}
+            </span>
+          )}
         </div>
         <p className="mt-1.5 text-xs leading-relaxed text-ink-faint">
           Final pricing confirmed after we connect.

--- a/apps/evrydayarchive-web/app/book/page.tsx
+++ b/apps/evrydayarchive-web/app/book/page.tsx
@@ -13,7 +13,7 @@ import {
 } from '@repo/core';
 
 import { getServerEnv } from '../lib/env';
-import { isSaleDiscountActive, applyDiscount, SALE } from '../lib/sale';
+import { isSaleAnnouncementActive } from '../lib/sale';
 import { BookingForm } from './booking-form';
 
 export const dynamic = 'force-dynamic';
@@ -24,15 +24,9 @@ type Props = {
     modifiers?: string;
     modifierValues?: string;
     from?: string;
+    sale?: string;
   }>;
 };
-
-const formatPrice = (cents: number): string =>
-  new Intl.NumberFormat('en-CA', {
-    style: 'currency',
-    currency: 'CAD',
-    maximumFractionDigits: 0
-  }).format(cents / 100);
 
 // ── Price helpers ─────────────────────────────────────────────────────────────
 
@@ -58,7 +52,8 @@ export default async function BookPage({ searchParams }: Props) {
     package: packageSlug,
     modifiers: modifiersParam,
     modifierValues: modifierValuesParam,
-    from
+    from,
+    sale
   } = await searchParams;
   const { ADMIN_API_BASE_URL } = getServerEnv();
 
@@ -129,10 +124,9 @@ export default async function BookPage({ searchParams }: Props) {
         }, 0)
       : undefined;
 
-  // During May 2026, booking requests get 10% off automatically.
-  const discountActive = isSaleDiscountActive();
-  const discountedTotalCents =
-    discountActive && estimatedTotalCents != null ? applyDiscount(estimatedTotalCents) : undefined;
+  // Spring Sale: opt-in via the package builder (sale=1 param).
+  // Date validation (must be a May date) happens client-side in BookingForm.
+  const springSale = sale === '1' && isSaleAnnouncementActive();
 
   const backHref =
     from === 'packages' || !pkg ? '/packages' : `/package-builder?package=${pkg.slug}`;
@@ -165,162 +159,19 @@ export default async function BookPage({ searchParams }: Props) {
           </p>
         </header>
 
-        {/* Two-column layout on desktop */}
+        {/* Two-column layout — BookingForm owns both the form and the reactive sidebar */}
         <div className="flex flex-col gap-12 lg:flex-row lg:items-start lg:gap-16">
-          {/* Form — left / full width on mobile */}
-          <div className="min-w-0 flex-1">
-            <BookingForm
-              pkg={pkg ?? null}
-              resolvedModifiers={resolvedModifiers}
-              modifierValues={modifierValues}
-              estimatedTotalCents={estimatedTotalCents}
-              discountedTotalCents={discountedTotalCents}
-              timeSlots={timeSlots}
-              locationWindows={locationWindows}
-            />
-          </div>
-
-          {/* Summary sidebar — desktop only */}
-          {pkg && (
-            <aside className="hidden lg:block lg:w-80 lg:flex-none lg:sticky lg:top-8">
-              <SummaryPanel
-                pkg={pkg}
-                resolvedModifiers={resolvedModifiers}
-                modifierValues={modifierValues}
-                estimatedTotalCents={estimatedTotalCents}
-                discountedTotalCents={discountedTotalCents}
-              />
-              <div className="mt-6 px-1">
-                <p className="mb-2 text-xs font-medium uppercase tracking-widest text-ink-faint">
-                  What happens next
-                </p>
-                <p className="text-sm leading-relaxed text-ink-muted">
-                  Once you submit, I&apos;ll review your request and be in touch to confirm the date
-                  and sort out any details.
-                </p>
-              </div>
-            </aside>
-          )}
+          <BookingForm
+            pkg={pkg ?? null}
+            resolvedModifiers={resolvedModifiers}
+            modifierValues={modifierValues}
+            estimatedTotalCents={estimatedTotalCents}
+            springSale={springSale}
+            timeSlots={timeSlots}
+            locationWindows={locationWindows}
+          />
         </div>
       </div>
     </main>
   );
 }
-
-// ── Summary panel (desktop sidebar) ──────────────────────────────────────────
-
-type SummaryPanelProps = {
-  pkg: PublicPackage;
-  resolvedModifiers: PublicPackageModifier[];
-  modifierValues: Record<string, number>;
-  estimatedTotalCents: number | undefined;
-  discountedTotalCents: number | undefined;
-};
-
-const modifierDisplayValue = (
-  m: PublicPackageModifier,
-  values: Record<string, number>
-): string | null => {
-  if (m.type === 'SLIDER') {
-    const cfg = m.config as SliderConfig | null;
-    if (!cfg) return null;
-    const v = values[m.id] ?? cfg.defaultValue;
-    return `${v}${cfg.unit}`;
-  }
-  if (m.type === 'INCREMENTER') {
-    const cfg = m.config as IncrementerConfig | null;
-    if (!cfg) return null;
-    const v = values[m.id] ?? cfg.defaultValue;
-    return `${v}${cfg.unit ? ` ${cfg.unit}` : ''}`;
-  }
-  return null;
-};
-
-const SummaryPanel = ({
-  pkg,
-  resolvedModifiers,
-  modifierValues,
-  estimatedTotalCents,
-  discountedTotalCents
-}: SummaryPanelProps) => (
-  <div className="rounded-card border border-border bg-sun px-6 py-6 shadow-warm-sm">
-    <p className="mb-4 text-xs font-medium uppercase tracking-widest text-ink-faint">
-      Your selection
-    </p>
-
-    {/* Package name + base price */}
-    <div className="mb-4 border-b border-border pb-4">
-      <h2 className="text-base font-semibold text-ink">{pkg.name}</h2>
-      {pkg.description && (
-        <p className="mt-1 text-sm leading-relaxed text-ink-muted">{pkg.description}</p>
-      )}
-      {pkg.basePriceCents != null && (
-        <p className="mt-2 text-xs text-ink-faint">
-          Base:{' '}
-          <span className="font-medium text-ink-muted">{formatPrice(pkg.basePriceCents)}</span>
-        </p>
-      )}
-    </div>
-
-    {/* Selected modifiers */}
-    {resolvedModifiers.length > 0 && (
-      <ul className="mb-4 space-y-2 border-b border-border pb-4">
-        {resolvedModifiers.map((m) => {
-          const delta = computeModifierDelta(m, modifierValues);
-          const displayVal = modifierDisplayValue(m, modifierValues);
-          return (
-            <li key={m.id} className="flex items-baseline justify-between gap-3 text-sm">
-              <span className="text-ink-muted">
-                {m.name}
-                {displayVal && <span className="ml-1 text-xs text-ink-faint">({displayVal})</span>}
-                {m.isRequired && !displayVal && (
-                  <span className="ml-1 text-xs text-ink-faint">(included)</span>
-                )}
-              </span>
-              {!m.isRequired && delta !== 0 && (
-                <span className="flex-none text-xs tabular-nums text-ink-faint">
-                  {delta > 0 ? '+' : '−'}
-                  {formatPrice(Math.abs(delta))}
-                </span>
-              )}
-            </li>
-          );
-        })}
-      </ul>
-    )}
-
-    {/* Estimated total */}
-    {estimatedTotalCents != null && (
-      <>
-        {discountedTotalCents != null && (
-          <div className="mb-3 flex items-center gap-2 rounded-card border border-accent/20 bg-accent/5 px-3 py-2">
-            <span className="font-mono text-[9px] font-bold uppercase tracking-widest text-accent/80">
-              {SALE.name}
-            </span>
-            <span className="text-xs text-accent">{SALE.discountLabel} applied</span>
-          </div>
-        )}
-        <div className="flex items-baseline justify-between">
-          <span className="text-sm font-medium text-ink-muted">Estimated total</span>
-          {discountedTotalCents != null ? (
-            <div className="flex flex-col items-end gap-0.5">
-              <span className="text-xs tabular-nums text-ink-faint line-through">
-                {formatPrice(estimatedTotalCents)}
-              </span>
-              <span className="text-xl font-semibold text-ink">
-                {formatPrice(discountedTotalCents)}
-              </span>
-            </div>
-          ) : (
-            <span className="text-xl font-semibold text-ink">
-              {formatPrice(estimatedTotalCents)}
-            </span>
-          )}
-        </div>
-        <p className="mt-1.5 text-xs leading-relaxed text-ink-faint">
-          Final pricing confirmed after we connect.
-        </p>
-      </>
-    )}
-  </div>
-);

--- a/apps/evrydayarchive-web/app/components/mobile-menu.tsx
+++ b/apps/evrydayarchive-web/app/components/mobile-menu.tsx
@@ -14,6 +14,10 @@ type MobileMenuProps = {
   isOpen: boolean;
   onClose: () => void;
   links: readonly NavLink[];
+  /** Tailwind class controlling how far the overlay stops from the bottom of the viewport.
+   *  Defaults to 'bottom-16' (clears the mobile nav bar only).
+   *  Pass 'bottom-[92px]' when the sale bar is also present. */
+  bottomOffset?: string;
 };
 
 /**
@@ -29,7 +33,13 @@ type MobileMenuProps = {
  * On release: close animation and navigation fire simultaneously so the
  * menu collapses downward while the new page loads behind it.
  */
-export const MobileMenu = ({ id, isOpen, onClose, links }: MobileMenuProps) => {
+export const MobileMenu = ({
+  id,
+  isOpen,
+  onClose,
+  links,
+  bottomOffset = 'bottom-16'
+}: MobileMenuProps) => {
   const pathname = usePathname();
   const allLinks: NavLink[] = [{ href: '/', label: 'Home' }, ...links];
 
@@ -41,7 +51,8 @@ export const MobileMenu = ({ id, isOpen, onClose, links }: MobileMenuProps) => {
       aria-label="Navigation menu"
       aria-hidden={!isOpen}
       className={cn(
-        'fixed inset-x-0 top-0 bottom-16 z-30 flex flex-col bg-canvas md:hidden',
+        'fixed inset-x-0 top-0 z-30 flex flex-col bg-canvas md:hidden',
+        bottomOffset,
         'transition-[clip-path] duration-standard',
         isOpen
           ? '[clip-path:inset(0%_0_0_0)] pointer-events-auto'

--- a/apps/evrydayarchive-web/app/components/site-header.tsx
+++ b/apps/evrydayarchive-web/app/components/site-header.tsx
@@ -280,7 +280,7 @@ export const SiteHeader = () => {
               mobileSaleOpen ? 'max-h-36 duration-standard' : 'max-h-0 duration-fast'
             )}
           >
-            <div className="border-b border-border bg-canvas px-4 pb-3 pt-3 text-center">
+            <div className="border-b border-border bg-sun px-4 pb-3 pt-3 text-center">
               <p className="text-sm leading-relaxed text-ink-muted">
                 Any sessions booked for May receive a 10% discount.
               </p>

--- a/apps/evrydayarchive-web/app/components/site-header.tsx
+++ b/apps/evrydayarchive-web/app/components/site-header.tsx
@@ -8,12 +8,16 @@ import { usePathname } from 'next/navigation';
 import { cn } from '../lib/cn';
 import { MobileMenu } from './mobile-menu';
 import { ThemeToggle } from './theme-toggle';
+import { isSaleAnnouncementActive, SALE } from '../lib/sale';
 
 const NAV = [
   { href: '/portfolio', label: 'Portfolio' },
   { href: '/about', label: 'About' },
   { href: '/packages', label: 'Packages' }
 ] as const;
+
+// Evaluated once at module load — same value on server and client during the sale window.
+const saleActive = isSaleAnnouncementActive();
 
 /**
  * Desktop nav link — orange underline animates left→right on hover/active.
@@ -61,33 +65,142 @@ const EstStamp = () => {
 /**
  * SiteHeader
  *
- * Mobile: fixed bottom bar — hamburger left, Inquire right.
- *         Always visible, no collapse. Logo lives in the page hero instead.
+ * Mobile: fixed bottom bar — hamburger left, logo centre, Inquire right.
+ *         A thin accent "APRIL SALE" strip sits immediately above it; tapping
+ *         it reveals a details panel that slides up from the strip.
  *
- * Desktop: sticky top bar — logo | nav links | theme toggle | Inquire CTA.
+ * Desktop: sticky top wrapper — logo | nav (+ "April Sale" toggle) | theme + Inquire.
+ *          Clicking "April Sale" expands a full-width panel below the nav bar.
  */
 export const SiteHeader = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [saleOpen, setSaleOpen] = useState(false);
+  const [mobileSaleOpen, setMobileSaleOpen] = useState(false);
 
   return (
     <>
+      {/* ── Desktop: sticky wrapper (nav bar + collapsible sale panel) ────── */}
+      <div className="hidden md:block md:sticky md:top-0 md:z-40">
+        {/* Nav bar */}
+        <div className="h-16 border-b border-border bg-canvas">
+          <div className="mx-auto flex h-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+            {/* Logo */}
+            <div className="group relative">
+              <Link
+                href="/"
+                aria-label="Evryday Archive Co — home"
+                className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
+              >
+                <Image
+                  src="/logo/horizontal.svg"
+                  alt="Evryday Archive Co"
+                  width={140}
+                  height={59}
+                  priority
+                  className="dark:hidden"
+                />
+                <Image
+                  src="/logo/horizontal-dark.svg"
+                  alt="Evryday Archive Co"
+                  width={140}
+                  height={59}
+                  priority
+                  className="hidden dark:block"
+                />
+              </Link>
+              <EstStamp />
+            </div>
+
+            {/* Nav links + optional sale toggle */}
+            <nav aria-label="Main navigation" className="flex items-center gap-8">
+              {NAV.map((link) => (
+                <NavLink key={link.href} href={link.href} label={link.label} />
+              ))}
+
+              {saleActive && (
+                <button
+                  type="button"
+                  onClick={() => setSaleOpen((o) => !o)}
+                  aria-expanded={saleOpen}
+                  className={cn(
+                    'flex items-center gap-1.5 text-sm font-medium text-accent',
+                    'transition-opacity duration-fast hover:opacity-75',
+                    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm'
+                  )}
+                >
+                  {SALE.name}
+                  <ChevronDown
+                    className={cn(
+                      'transition-transform duration-fast',
+                      saleOpen ? 'rotate-180' : 'rotate-0'
+                    )}
+                  />
+                </button>
+              )}
+            </nav>
+
+            {/* Right actions */}
+            <div className="flex items-center gap-3">
+              <ThemeToggle />
+              <Link
+                href="/inquire"
+                className="rounded-card bg-accent px-4 py-1.5 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              >
+                Inquire
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        {/* Sale panel — slides open below the nav bar */}
+        {saleActive && (
+          <div
+            className={cn(
+              'overflow-hidden transition-[max-height] ease-in-out',
+              saleOpen ? 'max-h-24 duration-standard' : 'max-h-0 duration-fast'
+            )}
+          >
+            <div className="flex items-center justify-between gap-4 bg-accent px-4 py-3 sm:px-6 lg:px-8">
+              <p className="flex items-center gap-3 text-sm text-white">
+                <span className="font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-white/60">
+                  {SALE.name}
+                </span>
+                Book any session in May and get 10% off your shoot — no code needed.
+              </p>
+              <div className="flex flex-none items-center gap-3">
+                <Link
+                  href="/book"
+                  onClick={() => setSaleOpen(false)}
+                  className="rounded-card bg-white/20 px-3 py-1 text-xs font-medium text-white transition-colors duration-fast hover:bg-white/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+                >
+                  Book now →
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => setSaleOpen(false)}
+                  aria-label="Close April Sale banner"
+                  className="text-white/60 transition-colors duration-fast hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-white focus-visible:rounded-sm"
+                >
+                  <XIcon size={14} />
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* ── Mobile: fixed bottom nav bar ─────────────────────────────────── */}
       <header
         className={cn(
-          // Mobile: fixed bottom bar, always h-16, no collapse.
-          // will-change-transform promotes to its own GPU layer, preventing
-          // content bleed-through during scroll on certain mobile browsers.
           'fixed bottom-0 z-40 w-full h-16 border-t border-border bg-canvas will-change-transform',
-          // Desktop: sticky top bar.
-          'md:sticky md:top-0 md:bottom-auto md:h-16 md:border-t-0 md:border-b md:overflow-hidden'
+          'md:hidden'
         )}
       >
-        <div className="mx-auto flex h-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
-          {/* ── Mobile layout ───────────────────────────────────────
-           * Closed: [☰ left] ........................ [Inquire right]
-           * Open:   [✕ left] [Inquire — fills remaining width      ]
-           * Transition: padding + flex-grow animate via transition-all.
+        <div className="mx-auto flex h-full max-w-7xl items-center justify-between px-4">
+          {/*
+           * Closed: [☰ left] .............. [logo centre] .............. [Inquire right]
            */}
-          <div className="grid w-full grid-cols-3 items-center md:hidden">
+          <div className="grid w-full grid-cols-3 items-center">
             <button
               type="button"
               onClick={() => setMobileMenuOpen((o) => !o)}
@@ -96,7 +209,7 @@ export const SiteHeader = () => {
               aria-controls="mobile-menu"
               className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-card text-ink-muted transition-colors hover:bg-sun focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
             >
-              {mobileMenuOpen ? <XIcon /> : <MenuIcon />}
+              {mobileMenuOpen ? <XIcon size={18} /> : <MenuIcon />}
             </button>
 
             <div className="flex justify-center">
@@ -133,63 +246,67 @@ export const SiteHeader = () => {
               </Link>
             </div>
           </div>
+        </div>
+      </header>
 
-          {/* ── Desktop layout ─────────────────────────────────────── */}
-          <div className="hidden w-full items-center justify-between md:flex">
-            <div className="group relative">
+      {/* ── Mobile: sale bar (persistent, sits above bottom nav) ─────────── */}
+      {saleActive && (
+        <div className="fixed bottom-16 left-0 right-0 z-40 bg-accent md:hidden">
+          {/* Expanded detail panel — reveals upward from the thin label bar */}
+          <div
+            className={cn(
+              'overflow-hidden transition-[max-height] ease-in-out',
+              mobileSaleOpen ? 'max-h-36 duration-standard' : 'max-h-0 duration-fast'
+            )}
+          >
+            <div className="px-4 pb-3 pt-3">
+              <p className="text-sm leading-relaxed text-white">
+                Book any session in May and get 10% off your shoot — no code needed.
+              </p>
               <Link
-                href="/"
-                aria-label="Evryday Archive Co — home"
-                className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
+                href="/book"
+                onClick={() => setMobileSaleOpen(false)}
+                className="mt-2 inline-flex items-center text-xs font-medium text-white/80 underline underline-offset-2 transition-colors duration-fast hover:text-white"
               >
-                <Image
-                  src="/logo/horizontal.svg"
-                  alt="Evryday Archive Co"
-                  width={140}
-                  height={59}
-                  priority
-                  className="dark:hidden"
-                />
-                <Image
-                  src="/logo/horizontal-dark.svg"
-                  alt="Evryday Archive Co"
-                  width={140}
-                  height={59}
-                  priority
-                  className="hidden dark:block"
-                />
-              </Link>
-              <EstStamp />
-            </div>
-
-            <nav aria-label="Main navigation" className="flex items-center gap-8">
-              {NAV.map((link) => (
-                <NavLink key={link.href} href={link.href} label={link.label} />
-              ))}
-            </nav>
-
-            <div className="flex items-center gap-3">
-              <ThemeToggle />
-              <Link
-                href="/inquire"
-                className="rounded-card bg-accent px-4 py-1.5 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
-              >
-                Inquire
+                Book now →
               </Link>
             </div>
           </div>
+
+          {/* Thin label bar — always visible */}
+          <button
+            type="button"
+            onClick={() => setMobileSaleOpen((o) => !o)}
+            aria-expanded={mobileSaleOpen}
+            aria-label={mobileSaleOpen ? 'Close April Sale details' : 'View April Sale details'}
+            className="flex h-7 w-full items-center justify-center gap-1.5 text-white"
+          >
+            <span className="font-mono text-[9px] font-bold uppercase tracking-[0.2em]">
+              {SALE.name}
+            </span>
+            {/* Chevron points up (▲) when collapsed to suggest expanding upward */}
+            <ChevronDown
+              className={cn(
+                'transition-transform duration-fast',
+                mobileSaleOpen ? 'rotate-0' : 'rotate-180'
+              )}
+            />
+          </button>
         </div>
-      </header>
+      )}
 
       <MobileMenu
         id="mobile-menu"
         isOpen={mobileMenuOpen}
         onClose={() => setMobileMenuOpen(false)}
         links={NAV}
+        bottomOffset={saleActive ? 'bottom-[92px]' : 'bottom-16'}
       />
     </>
   );
 };
+
+// ── Icons ─────────────────────────────────────────────────────────────────────
 
 const MenuIcon = () => (
   <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
@@ -202,8 +319,27 @@ const MenuIcon = () => (
   </svg>
 );
 
-const XIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+const XIcon = ({ size = 18 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 18 18" fill="none" aria-hidden="true">
     <path d="M4 4l10 10M14 4L4 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const ChevronDown = ({ className }: { className?: string }) => (
+  <svg
+    width="12"
+    height="12"
+    viewBox="0 0 12 12"
+    fill="none"
+    aria-hidden="true"
+    className={className}
+  >
+    <path
+      d="M2 4l4 4 4-4"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
   </svg>
 );

--- a/apps/evrydayarchive-web/app/components/site-header.tsx
+++ b/apps/evrydayarchive-web/app/components/site-header.tsx
@@ -194,7 +194,7 @@ export const SiteHeader = () => {
                   <span className="inline-flex items-center whitespace-nowrap rounded-sm border border-accent/40 px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-accent">
                     {SALE.name}
                   </span>
-                  Book any session in May and get 10% off your shoot — no code needed.
+                  Any sessions booked for May receive a 10% discount.
                 </p>
                 <button
                   type="button"
@@ -280,17 +280,10 @@ export const SiteHeader = () => {
               mobileSaleOpen ? 'max-h-36 duration-standard' : 'max-h-0 duration-fast'
             )}
           >
-            <div className="border-b border-border bg-canvas px-4 pb-3 pt-3">
+            <div className="border-b border-border bg-canvas px-4 pb-3 pt-3 text-center">
               <p className="text-sm leading-relaxed text-ink-muted">
-                Book any session in May and get 10% off your shoot — no code needed.
+                Any sessions booked for May receive a 10% discount.
               </p>
-              <Link
-                href="/book"
-                onClick={() => setMobileSaleOpen(false)}
-                className="mt-2 inline-flex items-center text-xs font-medium text-accent underline underline-offset-2 transition-opacity duration-fast hover:opacity-75"
-              >
-                Book now →
-              </Link>
             </div>
           </div>
 

--- a/apps/evrydayarchive-web/app/components/site-header.tsx
+++ b/apps/evrydayarchive-web/app/components/site-header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from './img';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
@@ -72,10 +72,37 @@ const EstStamp = () => {
  * Desktop: sticky top wrapper — logo | nav (+ "April Sale" toggle) | theme + Inquire.
  *          Clicking "April Sale" expands a full-width panel below the nav bar.
  */
+const SALE_BANNER_KEY = 'ea-sale-banner';
+
 export const SiteHeader = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  // Start closed to avoid SSR/hydration mismatch; effect opens it unless user dismissed it.
   const [saleOpen, setSaleOpen] = useState(false);
   const [mobileSaleOpen, setMobileSaleOpen] = useState(false);
+
+  // Open the banner by default on mount, unless the user has explicitly closed it.
+  useEffect(() => {
+    if (saleActive && localStorage.getItem(SALE_BANNER_KEY) !== 'closed') {
+      setSaleOpen(true);
+    }
+  }, []);
+
+  const handleSaleToggle = () => {
+    setSaleOpen((open) => {
+      const next = !open;
+      if (!next) {
+        localStorage.setItem(SALE_BANNER_KEY, 'closed');
+      } else {
+        localStorage.removeItem(SALE_BANNER_KEY);
+      }
+      return next;
+    });
+  };
+
+  const handleSaleClose = () => {
+    setSaleOpen(false);
+    localStorage.setItem(SALE_BANNER_KEY, 'closed');
+  };
 
   return (
     <>
@@ -120,7 +147,7 @@ export const SiteHeader = () => {
               {saleActive && (
                 <button
                   type="button"
-                  onClick={() => setSaleOpen((o) => !o)}
+                  onClick={handleSaleToggle}
                   aria-expanded={saleOpen}
                   className={cn(
                     'flex items-center gap-1.5 text-sm font-medium text-accent',
@@ -157,29 +184,23 @@ export const SiteHeader = () => {
           <div
             className={cn(
               'overflow-hidden transition-[max-height] ease-in-out',
-              saleOpen ? 'max-h-24 duration-standard' : 'max-h-0 duration-fast'
+              saleOpen ? 'max-h-16 duration-standard' : 'max-h-0 duration-fast'
             )}
           >
-            <div className="flex items-center justify-between gap-4 bg-accent px-4 py-3 sm:px-6 lg:px-8">
-              <p className="flex items-center gap-3 text-sm text-white">
-                <span className="font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-white/60">
-                  {SALE.name}
-                </span>
-                Book any session in May and get 10% off your shoot — no code needed.
-              </p>
-              <div className="flex flex-none items-center gap-3">
-                <Link
-                  href="/book"
-                  onClick={() => setSaleOpen(false)}
-                  className="rounded-card bg-white/20 px-3 py-1 text-xs font-medium text-white transition-colors duration-fast hover:bg-white/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
-                >
-                  Book now →
-                </Link>
+            <div className="border-b border-border bg-sun">
+              <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-2.5 sm:px-6 lg:px-8">
+                <p className="flex items-center gap-3 text-sm text-ink-muted">
+                  {/* Accent stamp — same visual language as the EST. 2025 detail */}
+                  <span className="inline-flex items-center whitespace-nowrap rounded-sm border border-accent/40 px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-accent">
+                    {SALE.name}
+                  </span>
+                  Book any session in May and get 10% off your shoot — no code needed.
+                </p>
                 <button
                   type="button"
-                  onClick={() => setSaleOpen(false)}
+                  onClick={handleSaleClose}
                   aria-label="Close April Sale banner"
-                  className="text-white/60 transition-colors duration-fast hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-white focus-visible:rounded-sm"
+                  className="flex-none text-ink-faint transition-colors duration-fast hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
                 >
                   <XIcon size={14} />
                 </button>
@@ -251,43 +272,43 @@ export const SiteHeader = () => {
 
       {/* ── Mobile: sale bar (persistent, sits above bottom nav) ─────────── */}
       {saleActive && (
-        <div className="fixed bottom-16 left-0 right-0 z-40 bg-accent md:hidden">
-          {/* Expanded detail panel — reveals upward from the thin label bar */}
+        <div className="fixed bottom-16 left-0 right-0 z-40 md:hidden">
+          {/* Expanded detail panel — bg-canvas, reveals upward from the thin label bar */}
           <div
             className={cn(
               'overflow-hidden transition-[max-height] ease-in-out',
               mobileSaleOpen ? 'max-h-36 duration-standard' : 'max-h-0 duration-fast'
             )}
           >
-            <div className="px-4 pb-3 pt-3">
-              <p className="text-sm leading-relaxed text-white">
+            <div className="border-b border-border bg-canvas px-4 pb-3 pt-3">
+              <p className="text-sm leading-relaxed text-ink-muted">
                 Book any session in May and get 10% off your shoot — no code needed.
               </p>
               <Link
                 href="/book"
                 onClick={() => setMobileSaleOpen(false)}
-                className="mt-2 inline-flex items-center text-xs font-medium text-white/80 underline underline-offset-2 transition-colors duration-fast hover:text-white"
+                className="mt-2 inline-flex items-center text-xs font-medium text-accent underline underline-offset-2 transition-opacity duration-fast hover:opacity-75"
               >
                 Book now →
               </Link>
             </div>
           </div>
 
-          {/* Thin label bar — always visible */}
+          {/* Thin label bar — bg-sun, always visible */}
           <button
             type="button"
             onClick={() => setMobileSaleOpen((o) => !o)}
             aria-expanded={mobileSaleOpen}
             aria-label={mobileSaleOpen ? 'Close April Sale details' : 'View April Sale details'}
-            className="flex h-7 w-full items-center justify-center gap-1.5 text-white"
+            className="flex h-7 w-full items-center justify-center gap-1.5 bg-sun"
           >
-            <span className="font-mono text-[9px] font-bold uppercase tracking-[0.2em]">
+            <span className="font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-accent">
               {SALE.name}
             </span>
             {/* Chevron points up (▲) when collapsed to suggest expanding upward */}
             <ChevronDown
               className={cn(
-                'transition-transform duration-fast',
+                'text-accent/70 transition-transform duration-fast',
                 mobileSaleOpen ? 'rotate-0' : 'rotate-180'
               )}
             />

--- a/apps/evrydayarchive-web/app/layout.tsx
+++ b/apps/evrydayarchive-web/app/layout.tsx
@@ -10,6 +10,7 @@ import { SiteHeader } from './components/site-header';
 import { SiteFooter } from './components/site-footer';
 import { NavigationFeedback } from './components/navigation-feedback';
 import { PageFade } from './components/page-fade';
+import { isSaleAnnouncementActive } from './lib/sale';
 
 const plusJakartaSans = Plus_Jakarta_Sans({
   subsets: ['latin'],
@@ -100,6 +101,7 @@ const jsonLd = {
 };
 
 const isComingSoon = process.env.NEXT_PUBLIC_COMING_SOON === 'true';
+const saleActive = isSaleAnnouncementActive();
 
 const RootLayout = ({ children }: { children: ReactNode }) => {
   return (
@@ -134,8 +136,9 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
         <ThemeProvider>
           {!isComingSoon && <SiteHeader />}
           <NavigationFeedback />
-          {/* pb-16 on mobile reserves space for the fixed bottom nav bar */}
-          <div className="pb-16 md:pb-0">
+          {/* pb-16 on mobile reserves space for the fixed bottom nav bar.
+               When the sale bar (h-7 = 28px) is also present, add another 28px → 92px total. */}
+          <div className={saleActive ? 'pb-[92px] md:pb-0' : 'pb-16 md:pb-0'}>
             <PageFade>{children}</PageFade>
           </div>
           {!isComingSoon && <SiteFooter />}

--- a/apps/evrydayarchive-web/app/lib/sale.ts
+++ b/apps/evrydayarchive-web/app/lib/sale.ts
@@ -1,0 +1,43 @@
+/**
+ * April Sale — May 2026 promotion.
+ *
+ * Any booking request submitted in May 2026 receives 10% off.
+ * The announcement bar is visible from mid-April through end of May.
+ *
+ * Remove or update this file when the sale ends.
+ */
+
+export const SALE = {
+  name: 'April Sale',
+  discountRate: 0.1,
+  discountLabel: '10% off',
+  /** Month (0-indexed) in which submitted bookings get the discount. May = 4. */
+  discountMonth: 4,
+  discountYear: 2026
+} as const;
+
+/**
+ * True while the announcement bar should be visible.
+ * Runs from now through end of May 2026.
+ */
+export function isSaleAnnouncementActive(): boolean {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth(); // 0-indexed
+  if (year < 2026) return true; // before 2026 — show during development
+  if (year > 2026) return false;
+  return month <= SALE.discountMonth; // Jan–May 2026
+}
+
+/**
+ * True when a booking submitted right now qualifies for the discount (May 2026 only).
+ */
+export function isSaleDiscountActive(): boolean {
+  const now = new Date();
+  return now.getFullYear() === SALE.discountYear && now.getMonth() === SALE.discountMonth;
+}
+
+/** Apply the sale discount to a price in cents, rounding to nearest cent. */
+export function applyDiscount(cents: number): number {
+  return Math.round(cents * (1 - SALE.discountRate));
+}

--- a/apps/evrydayarchive-web/app/lib/sale.ts
+++ b/apps/evrydayarchive-web/app/lib/sale.ts
@@ -1,14 +1,14 @@
 /**
- * April Sale — May 2026 promotion.
+ * Spring Sale — May 2026 promotion.
  *
- * Any booking request submitted in May 2026 receives 10% off.
+ * Any session booked for May 2026 receives 10% off.
  * The announcement bar is visible from mid-April through end of May.
  *
  * Remove or update this file when the sale ends.
  */
 
 export const SALE = {
-  name: 'April Sale',
+  name: 'Spring Sale',
   discountRate: 0.1,
   discountLabel: '10% off',
   /** Month (0-indexed) in which submitted bookings get the discount. May = 4. */

--- a/apps/evrydayarchive-web/app/lib/sale.ts
+++ b/apps/evrydayarchive-web/app/lib/sale.ts
@@ -41,3 +41,16 @@ export function isSaleDiscountActive(): boolean {
 export function applyDiscount(cents: number): number {
   return Math.round(cents * (1 - SALE.discountRate));
 }
+
+/**
+ * Returns true if a YYYY-MM-DD date string falls within the sale's discount month.
+ * Used client-side on the booking page to validate the selected shoot date.
+ */
+export function isSaleDate(dateStr: string): boolean {
+  if (!dateStr) return false;
+  const parts = dateStr.split('-');
+  if (parts.length < 2) return false;
+  const year = parseInt(parts[0]!, 10);
+  const month = parseInt(parts[1]!, 10); // 1-indexed in YYYY-MM-DD
+  return year === SALE.discountYear && month === SALE.discountMonth + 1;
+}

--- a/apps/evrydayarchive-web/app/lib/sale.ts
+++ b/apps/evrydayarchive-web/app/lib/sale.ts
@@ -30,6 +30,19 @@ export function isSaleAnnouncementActive(): boolean {
 }
 
 /**
+ * True during April and May 2026 — the window when the Spring Sale toggle should be
+ * pre-selected for users who land on the builder or booking page without having opted in.
+ */
+export function isSaleAutoOptIn(): boolean {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth(); // 0-indexed
+  if (year < 2026) return true; // before 2026 — dev convenience
+  if (year > 2026) return false;
+  return month === 3 || month === SALE.discountMonth; // April (3) or May (4)
+}
+
+/**
  * True when a booking submitted right now qualifies for the discount (May 2026 only).
  */
 export function isSaleDiscountActive(): boolean {

--- a/apps/evrydayarchive-web/app/package-builder/builder-card.tsx
+++ b/apps/evrydayarchive-web/app/package-builder/builder-card.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useCallback, useMemo, useState } from 'react';
+import { isSaleAnnouncementActive, applyDiscount, SALE } from '../lib/sale';
 
 import type {
   IncrementerConfig,
@@ -148,8 +149,11 @@ const modifierToItem = (m: PublicPackageModifier): BuilderItem => ({
 
 // ── Main component ────────────────────────────────────────────────────────────
 
+const saleAnnouncementActive = isSaleAnnouncementActive();
+
 export const BuilderCard = ({ pkg }: { pkg: PublicPackage }) => {
   const [items, setItems] = useState<BuilderItem[]>(() => pkg.modifiers.map(modifierToItem));
+  const [springSaleEnabled, setSpringSaleEnabled] = useState(false);
 
   const updateControl = useCallback((id: string, next: Partial<ControlState>) => {
     setItems((prev) => {
@@ -164,6 +168,10 @@ export const BuilderCard = ({ pkg }: { pkg: PublicPackage }) => {
     () => (pkg.basePriceCents ?? 0) + items.reduce((sum, item) => sum + itemPriceDelta(item), 0),
     [items, pkg.basePriceCents]
   );
+
+  // Discount amount in cents when spring sale is toggled on
+  const springDiscount = springSaleEnabled ? total - applyDiscount(total) : undefined;
+  const displayTotal = springDiscount != null ? total - springDiscount : total;
 
   const queryString = useMemo(() => {
     const params = new URLSearchParams({ package: pkg.slug });
@@ -194,8 +202,10 @@ export const BuilderCard = ({ pkg }: { pkg: PublicPackage }) => {
       );
     }
 
+    if (springSaleEnabled) params.set('sale', '1');
+
     return `?${params.toString()}`;
-  }, [items, pkg.slug]);
+  }, [items, pkg.slug, springSaleEnabled]);
 
   return (
     <div className="mx-auto w-full max-w-3xl">
@@ -219,12 +229,19 @@ export const BuilderCard = ({ pkg }: { pkg: PublicPackage }) => {
             )}
           </div>
 
-          {/* Modifier rows */}
-          {items.length > 0 && (
+          {/* Modifier rows + optional Spring Sale row */}
+          {(items.length > 0 || saleAnnouncementActive) && (
             <div className="divide-y divide-border">
               {items.map((item) => (
                 <ModifierRow key={item.id} item={item} allItems={items} onChange={updateControl} />
               ))}
+              {saleAnnouncementActive && (
+                <SpringSaleRow
+                  enabled={springSaleEnabled}
+                  discountCents={springDiscount ?? 0}
+                  onToggle={(checked) => setSpringSaleEnabled(checked)}
+                />
+              )}
             </div>
           )}
 
@@ -232,7 +249,18 @@ export const BuilderCard = ({ pkg }: { pkg: PublicPackage }) => {
           <div className="border-t border-border px-7 py-6">
             <div className="mb-5 flex items-baseline justify-between">
               <span className="text-sm font-medium text-ink-muted">Estimated total</span>
-              <span className="text-2xl font-semibold text-ink">{formatPrice(total)}</span>
+              {springDiscount != null ? (
+                <div className="flex flex-col items-end gap-0.5">
+                  <span className="text-sm tabular-nums text-ink-faint line-through">
+                    {formatPrice(total)}
+                  </span>
+                  <span className="text-2xl font-semibold text-ink">
+                    {formatPrice(displayTotal)}
+                  </span>
+                </div>
+              ) : (
+                <span className="text-2xl font-semibold text-ink">{formatPrice(total)}</span>
+              )}
             </div>
             <p className="mb-5 text-xs leading-relaxed text-ink-faint">
               Prices are estimates. Final scope and pricing is confirmed after we talk through the
@@ -257,7 +285,7 @@ export const BuilderCard = ({ pkg }: { pkg: PublicPackage }) => {
 
         {/* ── Sticky price widget (desktop only) ───────────────────── */}
         <aside className="sticky top-6 hidden w-52 shrink-0 lg:block">
-          <PriceWidget pkg={pkg} items={items} total={total} />
+          <PriceWidget pkg={pkg} items={items} total={total} springDiscount={springDiscount} />
         </aside>
       </div>
     </div>
@@ -270,14 +298,17 @@ type PriceWidgetProps = {
   pkg: PublicPackage;
   items: BuilderItem[];
   total: number;
+  springDiscount: number | undefined;
 };
 
-const PriceWidget = ({ pkg, items, total }: PriceWidgetProps) => {
+const PriceWidget = ({ pkg, items, total, springDiscount }: PriceWidgetProps) => {
   const activeLines = useMemo(() => {
     return items
       .map((item) => ({ name: item.name, delta: itemPriceDelta(item) }))
       .filter((line) => line.delta !== 0);
   }, [items]);
+
+  const displayTotal = springDiscount != null ? total - springDiscount : total;
 
   return (
     <div className="rounded-card border border-border bg-canvas p-5 shadow-warm-sm">
@@ -305,15 +336,59 @@ const PriceWidget = ({ pkg, items, total }: PriceWidgetProps) => {
             </span>
           </div>
         ))}
+        {springDiscount != null && (
+          <div className="flex items-baseline justify-between gap-2">
+            <span className="truncate text-accent">{SALE.name}</span>
+            <span className="shrink-0 tabular-nums text-accent">
+              −{formatPrice(springDiscount)}
+            </span>
+          </div>
+        )}
       </div>
 
       <div className="mt-4 flex items-baseline justify-between border-t border-border pt-4">
         <span className="text-xs text-ink-faint">Total</span>
-        <span className="text-xl font-semibold tabular-nums text-ink">{formatPrice(total)}</span>
+        <span className="text-xl font-semibold tabular-nums text-ink">
+          {formatPrice(displayTotal)}
+        </span>
       </div>
     </div>
   );
 };
+
+// ── SpringSaleRow ─────────────────────────────────────────────────────────────
+
+type SpringSaleRowProps = {
+  enabled: boolean;
+  discountCents: number;
+  onToggle: (checked: boolean) => void;
+};
+
+const SpringSaleRow = ({ enabled, discountCents, onToggle }: SpringSaleRowProps) => (
+  <div className="flex items-center gap-4 bg-sun px-7 py-5">
+    <div className="min-w-0 flex-1">
+      <div className="mb-1">
+        <span className="inline-flex items-center whitespace-nowrap rounded-sm border border-accent/40 px-1.5 py-[3px] font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-accent">
+          {SALE.name}
+        </span>
+      </div>
+      <p className="text-xs leading-relaxed text-ink-faint">
+        Book for May and receive 10% off — discount confirmed at checkout.
+      </p>
+    </div>
+    <div className="flex flex-none flex-col items-end gap-1.5">
+      <CheckboxControl checked={enabled} label="Apply Spring Sale discount" onChange={onToggle} />
+      <span
+        className={[
+          'text-xs font-medium tabular-nums',
+          enabled ? 'text-accent' : 'text-ink-faint'
+        ].join(' ')}
+      >
+        {enabled ? `−${formatPrice(discountCents)}` : `−${SALE.discountRate * 100}%`}
+      </span>
+    </div>
+  </div>
+);
 
 // ── ModifierRow ───────────────────────────────────────────────────────────────
 

--- a/apps/evrydayarchive-web/app/package-builder/builder-card.tsx
+++ b/apps/evrydayarchive-web/app/package-builder/builder-card.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useCallback, useMemo, useState } from 'react';
-import { isSaleAnnouncementActive, applyDiscount, SALE } from '../lib/sale';
+import { isSaleAnnouncementActive, isSaleAutoOptIn, applyDiscount, SALE } from '../lib/sale';
 
 import type {
   IncrementerConfig,
@@ -153,7 +153,7 @@ const saleAnnouncementActive = isSaleAnnouncementActive();
 
 export const BuilderCard = ({ pkg }: { pkg: PublicPackage }) => {
   const [items, setItems] = useState<BuilderItem[]>(() => pkg.modifiers.map(modifierToItem));
-  const [springSaleEnabled, setSpringSaleEnabled] = useState(false);
+  const [springSaleEnabled, setSpringSaleEnabled] = useState(() => isSaleAutoOptIn());
 
   const updateControl = useCallback((id: string, next: Partial<ControlState>) => {
     setItems((prev) => {


### PR DESCRIPTION
## Summary

- Adds a collapsible **Spring Sale** announcement bar to the site header — desktop has a nav toggle with a chevron, mobile has a persistent thin bar above the bottom nav that expands upward
- Banner opens by default on load and remembers its dismissed state via `localStorage`
- Adds a **Spring Sale toggle** to the package builder that applies a live 10% discount to the displayed total and updates the booking URL with `sale=1`
- Booking page applies the discount reactively: active whenever a May date is selected (regardless of whether the user came from the builder), clears immediately if a non-May date is picked, and shows a clarifying note in both the mobile summary card and the desktop sidebar
- Calendar highlights all May days with a light orange tint and adds a Spring Sale legend entry when viewing that month
- All sale config lives in `app/lib/sale.ts` — name, discount rate, month, year, and helper functions (`isSaleAnnouncementActive`, `isSaleDate`, `applyDiscount`)

## Test plan

- [ ] Desktop: "Spring Sale" nav toggle opens/closes the banner; closing persists across page navigation; reopening clears the dismissed state
- [ ] Mobile: thin sale bar above bottom nav toggles expanded detail panel
- [ ] Package builder: Spring Sale row applies 10% discount live; `sale=1` is included in the booking URL when enabled
- [ ] Booking page (direct): navigate to `/book`, open calendar, navigate to May — days should be orange-tinted with legend; select a May date — discount appears in mobile summary card and desktop sidebar; switch to a non-May date — discount clears and note appears
- [ ] Booking page (from builder): same as above, plus pending discount shown before a date is selected
- [ ] `isSaleAnnouncementActive` returns `true` before 2026 (dev) and through end of May 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)