### PR TITLE
Add Meta Pixel tracking

### DIFF
--- a/apps/evrydayarchive-web/app/components/meta-pixel.tsx
+++ b/apps/evrydayarchive-web/app/components/meta-pixel.tsx
@@ -1,0 +1,36 @@
+import Script from 'next/script';
+
+const pixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID;
+
+export const MetaPixel = () => {
+  if (!pixelId) return null;
+
+  return (
+    <>
+      <Script id="meta-pixel" strategy="afterInteractive">
+        {`
+          !function(f,b,e,v,n,t,s)
+          {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+          n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+          if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+          n.queue=[];t=b.createElement(e);t.async=!0;
+          t.src=v;s=b.getElementsByTagName(e)[0];
+          s.parentNode.insertBefore(t,s)}(window, document,'script',
+          'https://connect.facebook.net/en_US/fbevents.js');
+          fbq('init', '${pixelId}');
+          fbq('track', 'PageView');
+        `}
+      </Script>
+      <noscript>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          height="1"
+          width="1"
+          style={{ display: 'none' }}
+          src={`https://www.facebook.com/tr?id=${pixelId}&ev=PageView&noscript=1`}
+          alt=""
+        />
+      </noscript>
+    </>
+  );
+};

--- a/apps/evrydayarchive-web/app/layout.tsx
+++ b/apps/evrydayarchive-web/app/layout.tsx
@@ -10,6 +10,7 @@ import { SiteHeader } from './components/site-header';
 import { SiteFooter } from './components/site-footer';
 import { NavigationFeedback } from './components/navigation-feedback';
 import { PageFade } from './components/page-fade';
+import { MetaPixel } from './components/meta-pixel';
 import { isSaleAnnouncementActive } from './lib/sale';
 
 const plusJakartaSans = Plus_Jakarta_Sans({
@@ -155,6 +156,7 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
         </ThemeProvider>
         <Analytics />
         <SpeedInsights />
+        <MetaPixel />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Adds Meta Pixel to `evrydayarchive-web` via a `MetaPixel` component
- Pixel ID read from `NEXT_PUBLIC_META_PIXEL_ID` env var — pixel is a no-op if the var is unset (safe in dev/preview)
- Uses Next.js `<Script strategy="afterInteractive">` to avoid render-blocking

## Test plan
- [ ] Verify `NEXT_PUBLIC_META_PIXEL_ID` is set in Vercel production environment
- [ ] After deploy, confirm pixel fires in Meta Events Manager or browser network tab (`connect.facebook.net/en_US/fbevents.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)