### PR TITLE
Add receipt-style modifier breakdown to booking emails

### DIFF
--- a/.github/workflows/release-to-production.yml
+++ b/.github/workflows/release-to-production.yml
@@ -1,23 +1,41 @@
 name: Release to Production
 
 # Triggered when a release is published from the GitHub UI or CLI.
-# Fast-forwards the `production` branch to the release tag so Vercel
-# picks it up and deploys automatically.
+# Runs database migrations against production first, then fast-forwards
+# the `production` branch to the release tag so Vercel picks it up and deploys.
 on:
   release:
     types: [published]
 
 jobs:
   deploy:
-    name: Fast-forward production to release tag
+    name: Migrate and release to production
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Needs write access to push production
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run database migrations
+        run: pnpm db:deploy
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_PROD_OWNER_URL }}
 
       - name: Fast-forward production to ${{ github.ref_name }}
         run: |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Apps must not import from other apps. All shared code goes through `@repo/core`,
 
 - Node.js 20+
 - pnpm 9+
-- A running PostgreSQL instance (or use the Neon connection string from `.env`)
 
 ### 1) Install dependencies
 
@@ -35,46 +34,46 @@ pnpm install
 
 ### 2) Configure environment variables
 
-Copy the example files and fill in any blank values:
+Two files need to exist locally. They are gitignored and never committed.
+
+**`packages/db/.env`** — read by Prisma CLI (`db:migrate`, `db:deploy`, `db:studio`, etc.):
+
+```bash
+cp packages/db/.env.example packages/db/.env
+# then fill in DATABASE_URL with the dev branch connection string from Neon
+```
+
+**`apps/admin/.env`** — read by the running Next.js admin app:
 
 ```bash
 cp apps/admin/.env.example apps/admin/.env
-cp apps/evrydayarchive-web/.env.example apps/evrydayarchive-web/.env
+# then fill in all values
 ```
-
-**`apps/admin/.env`** — required vars:
 
 | Variable                | Purpose                                    |
 | ----------------------- | ------------------------------------------ |
-| `DATABASE_URL`          | PostgreSQL connection string               |
+| `DATABASE_URL`          | Neon dev branch connection string          |
 | `ADMIN_PASSWORD`        | Login password for the admin UI            |
 | `AUTH_SECRET`           | Session signing secret (any random string) |
+| `RESEND_API_KEY`        | Resend — transactional email               |
+| `NOTIFICATION_EMAIL`    | Address that receives booking alerts       |
 | `CLOUDINARY_CLOUD_NAME` | Cloudinary account — image uploads         |
 | `CLOUDINARY_API_KEY`    | Cloudinary API key                         |
 | `CLOUDINARY_API_SECRET` | Cloudinary API secret                      |
 
-**`apps/evrydayarchive-web/.env`** — required vars:
+`DATABASE_URL` must be identical in both files — they read the same DB, from different contexts (CLI vs runtime).
 
-| Variable                  | Purpose                                                     |
-| ------------------------- | ----------------------------------------------------------- |
-| `ADMIN_API_BASE_URL`      | Base URL of the admin app (for fetching galleries/packages) |
-| `DATABASE_URL`            | PostgreSQL connection string (used for waitlist writes)     |
-| `NEXT_PUBLIC_COMING_SOON` | Set `"true"` to redirect all routes to `/coming-soon`       |
-
-For Prisma CLI commands run directly from `packages/db`, also create:
+**`apps/evrydayarchive-web/.env`** — the public site does not connect to the DB directly (it goes through the admin API), so `DATABASE_URL` is not needed here:
 
 ```bash
-cp apps/admin/.env packages/db/.env   # or set DATABASE_URL manually
+cp apps/evrydayarchive-web/.env.example apps/evrydayarchive-web/.env
 ```
 
-### 3) Generate Prisma client and run migrations
+| Variable             | Purpose                                                  |
+| -------------------- | -------------------------------------------------------- |
+| `ADMIN_API_BASE_URL` | Base URL of the admin app (e.g. `http://localhost:3001`) |
 
-```bash
-pnpm --filter @repo/db db:generate
-pnpm --filter @repo/db db:migrate
-```
-
-### 4) Start the apps
+### 3) Start the apps
 
 ```bash
 pnpm dev                             # all apps in parallel
@@ -84,39 +83,99 @@ pnpm --filter admin dev              # admin only (port 3001)
 
 ---
 
-## Deployment & hosting
+## Database
 
-| App                  | Host              | Domain                    |
-| -------------------- | ----------------- | ------------------------- |
-| `evrydayarchive-web` | Vercel            | `evrydayarchive.co`       |
-| `admin`              | Vercel            | `admin.evrydayarchive.co` |
-| Database             | Neon (PostgreSQL) | shared across envs        |
+### Setup
 
-Both apps are deployed as separate Vercel projects, each configured via the Vercel dashboard (build commands, env vars, domains). There is no `vercel.json` in the repo — all deployment config lives in the Vercel UI.
+One Neon project (`brand-websites-db-production`) with two branches:
 
-The public site's `ADMIN_API_BASE_URL` is set in its Vercel project env vars and points to `admin.evrydayarchive.co`.
+| Branch        | Used by                                |
+| ------------- | -------------------------------------- |
+| `production`  | Vercel production deployment           |
+| `development` | Local dev + Vercel preview deployments |
 
-**Coming-soon mode** is controlled by `NEXT_PUBLIC_COMING_SOON=true` in the public app's environment. When enabled, middleware redirects all routes to `/coming-soon` except `/api/*`. The coming-soon page includes a waitlist email capture form.
+Your local `DATABASE_URL` always points to the `development` branch. Get the connection string from the Neon console: open the project → select the `development` branch → Connection details → choose the `local_development` role.
+
+### The two commands — and when to use each
+
+| Command           | When                                                         | What it does                                                                                                                             |
+| ----------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm db:migrate` | **Local dev only.** After editing `schema.prisma`.           | Creates a new `.sql` migration file in `packages/db/prisma/migrations/`, applies it to your local DB, and regenerates the Prisma client. |
+| `pnpm db:deploy`  | **Deploying.** Applying migrations to production or preview. | Applies any pending migration files that are already in the repo. Creates nothing new.                                                   |
+
+The short version: **`migrate` creates migration files. `deploy` applies them.**
+
+Once a migration file exists in the repo (i.e. you ran `migrate` and committed), you never need to run `migrate` again for that change — only `deploy` on each target environment.
+
+### Workflow: making a schema change
+
+```bash
+# 1. Edit packages/db/prisma/schema.prisma
+
+# 2. Create the migration and apply it locally
+pnpm db:migrate
+# Prisma will prompt for a migration name (e.g. "add_user_preferences")
+
+# 3. Commit the migration file alongside your code changes
+git add packages/db/prisma/migrations/
+git commit -m "..."
+
+# 4. Apply to production after merging (see Deploying migrations below)
+```
+
+### Deploying migrations to production
+
+After merging code that includes a new migration, apply it to the production branch before or immediately after the Vercel deployment goes live:
+
+```bash
+DATABASE_URL="<production-branch-connection-string>" pnpm db:deploy
+```
+
+Get the production connection string from Neon: select the `production` branch → Connection details.
+
+Apply to the preview/development branch the same way if it has drifted:
+
+```bash
+# packages/db/.env already points at development branch, so just:
+pnpm db:deploy
+```
+
+### Other useful commands
+
+```bash
+pnpm db:status   # show which migrations are applied vs pending on the connected DB
+pnpm db:studio   # open Prisma Studio (visual DB browser) against your local DB
+```
+
+Run from `packages/db` directly for commands not aliased at the root:
+
+```bash
+pnpm --filter @repo/db db:reset        # drop and recreate all tables (destructive — dev only)
+pnpm --filter @repo/db db:reset:force  # same, skips confirmation prompt
+```
 
 ---
 
-## Database
+## Deployment & hosting
 
-Managed via Prisma in `packages/db`. The same Neon database is used in both local dev (pointed at by your local `.env` files) and in production.
+| App                  | Host              | Domain                         |
+| -------------------- | ----------------- | ------------------------------ |
+| `evrydayarchive-web` | Vercel            | `evrydayarchive.co`            |
+| `admin`              | Vercel            | `admin.evrydayarchive.co`      |
+| Database             | Neon (PostgreSQL) | `brand-websites-db-production` |
 
-```bash
-# Regenerate Prisma client after schema changes
-pnpm --filter @repo/db db:generate
+Both apps are deployed as separate Vercel projects configured via the Vercel dashboard. There is no `vercel.json` in the repo — all deployment config lives in the Vercel UI.
 
-# Create and apply a new migration
-pnpm --filter @repo/db db:migrate
+### Vercel environment variables
 
-# Reset the database (destructive — drops all tables)
-pnpm --filter @repo/db db:reset
-pnpm --filter @repo/db db:reset:force   # skips interactive confirmation
-```
+`DATABASE_URL` is scoped per environment in Vercel:
 
-Note: `db:reset` does not create the database itself — it must already exist.
+| Vercel environment | `DATABASE_URL` points at  |
+| ------------------ | ------------------------- |
+| Production         | Neon `production` branch  |
+| Preview            | Neon `development` branch |
+
+The public site's `ADMIN_API_BASE_URL` is set in its Vercel project env vars and points to `admin.evrydayarchive.co`.
 
 ---
 
@@ -124,7 +183,7 @@ Note: `db:reset` does not create the database itself — it must already exist.
 
 Single-password session auth. Set in `apps/admin/.env`:
 
-```bash
+```
 ADMIN_PASSWORD=your-strong-password
 AUTH_SECRET=some-random-string
 ```
@@ -166,12 +225,6 @@ Tests live alongside the code they test:
 - `packages/**/src/**/*.test.ts` — unit/contract tests for shared packages
 - `apps/**/app/**/route.test.ts` — integration tests for route handlers
 
-**Testing strategy (target ratios):**
-
-- Unit + integration: ~80–90% of the suite
-- Contract tests: ~10–15%
-- E2E smoke tests: ~5% (critical paths only — login, gallery publish, public portfolio)
-
 ---
 
 ## API contract
@@ -205,7 +258,9 @@ export const POST = async (req: Request): Promise<Response> => {
 
 ## Troubleshooting
 
-- **`Environment variable not found: DATABASE_URL`** — verify `.env` files exist in `apps/admin`, `apps/evrydayarchive-web`, and optionally `packages/db`.
+- **Server error on `/bookings` or other admin pages** — your local DB may be missing a migration. Run `pnpm db:status` to check, then `pnpm db:deploy` to apply any pending ones.
+- **`Environment variable not found: DATABASE_URL`** — verify `packages/db/.env` and `apps/admin/.env` both exist and contain `DATABASE_URL`.
 - **Public site shows no portfolio data** — ensure `ADMIN_API_BASE_URL` points to a running admin instance and that `pnpm --filter admin dev` is running.
 - **Admin login fails** — verify `ADMIN_PASSWORD` and `AUTH_SECRET` are set in `apps/admin/.env` and restart the dev server after changes.
+- **Booking emails not sending** — check `RESEND_API_KEY` and `NOTIFICATION_EMAIL` are set in `apps/admin/.env`. Navigate to the booking in `/bookings` on the admin — the email status section will show the exact error if one occurred.
 - **Cloudinary uploads fail** — verify `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, and `CLOUDINARY_API_SECRET` are set in `apps/admin/.env`.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ Two files need to exist locally. They are gitignored and never committed.
 
 ```bash
 cp packages/db/.env.example packages/db/.env
-# then fill in DATABASE_URL with the dev branch connection string from Neon
+# Set DATABASE_URL to the neondb_owner connection string for the development branch
 ```
+
+Use the **`neondb_owner` role** here. Migrations require DDL permissions (ALTER TABLE, CREATE TABLE) that Neon only grants to the owner role — application roles are restricted to DML only.
 
 **`apps/admin/.env`** — read by the running Next.js admin app:
 
@@ -52,7 +54,7 @@ cp apps/admin/.env.example apps/admin/.env
 
 | Variable                | Purpose                                    |
 | ----------------------- | ------------------------------------------ |
-| `DATABASE_URL`          | Neon dev branch connection string          |
+| `DATABASE_URL`          | Neon dev branch — `local_development` role |
 | `ADMIN_PASSWORD`        | Login password for the admin UI            |
 | `AUTH_SECRET`           | Session signing secret (any random string) |
 | `RESEND_API_KEY`        | Resend — transactional email               |
@@ -61,7 +63,9 @@ cp apps/admin/.env.example apps/admin/.env
 | `CLOUDINARY_API_KEY`    | Cloudinary API key                         |
 | `CLOUDINARY_API_SECRET` | Cloudinary API secret                      |
 
-`DATABASE_URL` must be identical in both files — they read the same DB, from different contexts (CLI vs runtime).
+Use the **`local_development` role** here. The running app only needs DML permissions (SELECT, INSERT, UPDATE, DELETE) — using a restricted role limits blast radius if credentials are ever exposed.
+
+Both files point at the same Neon `development` branch, but with different roles: owner for migrations, application role for the app.
 
 **`apps/evrydayarchive-web/.env`** — the public site does not connect to the DB directly (it goes through the admin API), so `DATABASE_URL` is not needed here:
 
@@ -128,10 +132,10 @@ git commit -m "..."
 After merging code that includes a new migration, apply it to the production branch before or immediately after the Vercel deployment goes live:
 
 ```bash
-DATABASE_URL="<production-branch-connection-string>" pnpm db:deploy
+DATABASE_URL="<production-branch-neondb_owner-connection-string>" pnpm db:deploy
 ```
 
-Get the production connection string from Neon: select the `production` branch → Connection details.
+Get the connection string from Neon: select the `production` branch → Connection details → **`neondb_owner` role**. The same DDL permission requirement applies — application roles cannot run migrations.
 
 Apply to the preview/development branch the same way if it has drifted:
 

--- a/apps/admin/app/api/bookings/[id]/resend/route.ts
+++ b/apps/admin/app/api/bookings/[id]/resend/route.ts
@@ -1,0 +1,84 @@
+import { createApiError, jsonError, jsonOk } from '@repo/core';
+import { prisma } from '@repo/db';
+
+import { requireAdminSession } from '../../../../lib/auth';
+import { sendBookingConfirmation, sendBookingNotification } from '../../../../lib/email';
+import { buildModifierLineItems } from '../../../../lib/modifiers';
+
+type BookingPayload = {
+  location?: string;
+  packageName?: string | null;
+  modifierIds?: string[];
+  modifierValues?: Record<string, number> | null;
+  estimatedTotalCents?: number | null;
+  preferredDate?: string;
+  preferredTime?: string | null;
+};
+
+type SelectedOptions = {
+  modifierIds?: string[];
+  modifierValues?: Record<string, number>;
+};
+
+export const POST = async (
+  req: Request,
+  { params }: { params: { id: string } }
+): Promise<Response> => {
+  const authError = requireAdminSession(req);
+  if (authError) return authError;
+
+  const booking = await prisma.bookingRequest.findUnique({
+    where: { id: params.id },
+    include: {
+      inquiry: true,
+      package: { include: { modifiers: { orderBy: { sortOrder: 'asc' } } } }
+    }
+  });
+
+  if (!booking || !booking.inquiry) {
+    return jsonError(createApiError('NOT_FOUND', 'Booking not found.'), 404);
+  }
+
+  const { inquiry } = booking;
+  const payload = inquiry.payload as BookingPayload | null;
+  const selectedOptions = booking.selectedOptions as SelectedOptions | null;
+
+  const modifierLineItems =
+    booking.package && selectedOptions
+      ? buildModifierLineItems(
+          booking.package.modifiers,
+          selectedOptions.modifierIds ?? [],
+          selectedOptions.modifierValues ?? {}
+        )
+      : undefined;
+
+  const emailData = {
+    name: inquiry.name,
+    email: inquiry.email,
+    phone: inquiry.phone ?? undefined,
+    location: payload?.location ?? '',
+    preferredDate: payload?.preferredDate ?? booking.requestedAt?.toISOString().slice(0, 10) ?? '',
+    preferredTime: payload?.preferredTime ?? undefined,
+    packageName: payload?.packageName ?? undefined,
+    estimatedTotalCents: payload?.estimatedTotalCents ?? undefined,
+    notes: inquiry.message ?? undefined,
+    inquiryId: inquiry.id,
+    modifierLineItems
+  };
+
+  try {
+    await Promise.all([sendBookingConfirmation(emailData), sendBookingNotification(emailData)]);
+    await prisma.bookingRequest.update({
+      where: { id: params.id },
+      data: { emailSentAt: new Date(), emailError: null }
+    });
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    await prisma.bookingRequest
+      .update({ where: { id: params.id }, data: { emailError: errorMsg } })
+      .catch(() => {});
+    return jsonError(createApiError('INTERNAL', `Email send failed: ${errorMsg}`));
+  }
+
+  return jsonOk({ resent: true });
+};

--- a/apps/admin/app/api/bookings/[id]/route.ts
+++ b/apps/admin/app/api/bookings/[id]/route.ts
@@ -1,0 +1,84 @@
+import {
+  BookingRequestUpdateSchema,
+  createApiError,
+  jsonError,
+  jsonOk,
+  parseJson
+} from '@repo/core';
+import { prisma } from '@repo/db';
+
+import { requireAdminSession } from '../../../lib/auth';
+
+export const GET = async (
+  req: Request,
+  { params }: { params: { id: string } }
+): Promise<Response> => {
+  const authError = requireAdminSession(req);
+  if (authError) return authError;
+
+  const booking = await prisma.bookingRequest.findUnique({
+    where: { id: params.id },
+    include: {
+      inquiry: true,
+      package: { include: { modifiers: { orderBy: { sortOrder: 'asc' } } } },
+      timeSlot: true
+    }
+  });
+
+  if (!booking) {
+    return jsonError(createApiError('NOT_FOUND', 'Booking not found.'), 404);
+  }
+
+  return jsonOk(booking);
+};
+
+export const PATCH = async (
+  req: Request,
+  { params }: { params: { id: string } }
+): Promise<Response> => {
+  const authError = requireAdminSession(req);
+  if (authError) return authError;
+
+  const result = await parseJson(req, BookingRequestUpdateSchema);
+  if (!result.ok) return jsonError(result.error);
+
+  try {
+    const booking = await prisma.bookingRequest.update({
+      where: { id: params.id },
+      data: result.data
+    });
+    return jsonOk(booking);
+  } catch {
+    return jsonError(createApiError('NOT_FOUND', 'Booking not found.'), 404);
+  }
+};
+
+export const DELETE = async (
+  req: Request,
+  { params }: { params: { id: string } }
+): Promise<Response> => {
+  const authError = requireAdminSession(req);
+  if (authError) return authError;
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      const booking = await tx.bookingRequest.findUnique({
+        where: { id: params.id },
+        select: { inquiryId: true }
+      });
+      if (!booking) throw new Error('NOT_FOUND');
+
+      await tx.bookingRequest.delete({ where: { id: params.id } });
+      if (booking.inquiryId) {
+        await tx.inquiry.delete({ where: { id: booking.inquiryId } });
+      }
+    });
+  } catch (err) {
+    if (err instanceof Error && err.message === 'NOT_FOUND') {
+      return jsonError(createApiError('NOT_FOUND', 'Booking not found.'), 404);
+    }
+    return jsonError(createApiError('INTERNAL', 'Failed to delete booking.'));
+  }
+
+  return jsonOk({ deleted: true });
+};

--- a/apps/admin/app/api/bookings/route.ts
+++ b/apps/admin/app/api/bookings/route.ts
@@ -1,0 +1,31 @@
+import { jsonOk } from '@repo/core';
+import { prisma } from '@repo/db';
+
+import { requireAdminSession } from '../../lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export const GET = async (req: Request): Promise<Response> => {
+  const authError = requireAdminSession(req);
+  if (authError) return authError;
+
+  const bookings = await prisma.bookingRequest.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: {
+      inquiry: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          phone: true,
+          status: true,
+          payload: true,
+          createdAt: true
+        }
+      },
+      package: { select: { id: true, name: true } }
+    }
+  });
+
+  return jsonOk(bookings);
+};

--- a/apps/admin/app/api/public/bookings/route.ts
+++ b/apps/admin/app/api/public/bookings/route.ts
@@ -2,75 +2,10 @@ import { BookingFormSchema, jsonError, jsonOk, parseJson } from '@repo/core';
 import { prisma } from '@repo/db';
 
 import { sendBookingConfirmation, sendBookingNotification } from '../../../lib/email';
+import { buildModifierLineItems } from '../../../lib/modifiers';
 import type { ModifierLineItem } from '../../../lib/email';
 
 // TODO: Rate limiting — add per-IP limits when infrastructure supports it.
-
-// ── Modifier config shapes (mirrors core schemas) ─────────────────────────────
-
-type SliderCfg = { defaultValue: number; step: number; pricePerStep: number; unit: string };
-type IncrementerCfg = { defaultValue: number; pricePerUnit: number; unit?: string };
-type ToggleCfg = { defaultLabel: string; altLabel: string };
-
-type DbModifier = {
-  id: string;
-  name: string;
-  type: string;
-  isRequired: boolean;
-  priceDeltaCents: number | null;
-  config: unknown;
-};
-
-const buildModifierLineItems = (
-  modifiers: DbModifier[],
-  selectedIds: string[],
-  values: Record<string, number>
-): ModifierLineItem[] => {
-  const items: ModifierLineItem[] = [];
-
-  for (const m of modifiers) {
-    const selected = m.isRequired || selectedIds.includes(m.id);
-    if (!selected) continue;
-
-    const cfg = m.config as Record<string, unknown> | null;
-
-    if (m.type === 'SLIDER') {
-      const c = cfg as SliderCfg | null;
-      if (!c) continue;
-      const value = values[m.id] ?? c.defaultValue;
-      const steps = Math.round((value - c.defaultValue) / c.step);
-      const delta = steps * c.pricePerStep;
-      items.push({
-        name: m.name,
-        displayValue: `${value}${c.unit}`,
-        priceDeltaCents: delta || null
-      });
-    } else if (m.type === 'INCREMENTER') {
-      const c = cfg as IncrementerCfg | null;
-      if (!c) continue;
-      const count = values[m.id] ?? c.defaultValue;
-      const delta = (count - c.defaultValue) * c.pricePerUnit;
-      items.push({
-        name: m.name,
-        displayValue: `${count}${c.unit ? ` ${c.unit}` : ''}`,
-        priceDeltaCents: delta || null
-      });
-    } else if (m.type === 'TOGGLE') {
-      const c = cfg as ToggleCfg | null;
-      const altActive = selectedIds.includes(m.id);
-      items.push({
-        name: m.name,
-        displayValue: c ? (altActive ? c.altLabel : c.defaultLabel) : undefined,
-        priceDeltaCents: altActive ? (m.priceDeltaCents ?? null) : null
-      });
-    } else {
-      // CHECKBOX
-      items.push({ name: m.name, priceDeltaCents: m.priceDeltaCents ?? null });
-    }
-  }
-
-  return items;
-};
 
 export const POST = async (req: Request): Promise<Response> => {
   const result = await parseJson(req, BookingFormSchema);
@@ -195,11 +130,22 @@ export const POST = async (req: Request): Promise<Response> => {
     modifierLineItems
   };
 
-  Promise.all([sendBookingConfirmation(emailData), sendBookingNotification(emailData)]).catch(
-    (err) => {
-      console.error('[bookings] Email send failed', { inquiryId: inquiry.id, err });
-    }
-  );
+  try {
+    await Promise.all([sendBookingConfirmation(emailData), sendBookingNotification(emailData)]);
+    await prisma.bookingRequest.update({
+      where: { id: inquiry.bookingRequest!.id },
+      data: { emailSentAt: new Date() }
+    });
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    console.error('[bookings] Email send failed', { inquiryId: inquiry.id, err });
+    await prisma.bookingRequest
+      .update({
+        where: { id: inquiry.bookingRequest!.id },
+        data: { emailError: errorMsg }
+      })
+      .catch(() => {});
+  }
 
   return jsonOk({ inquiryId: inquiry.id });
 };

--- a/apps/admin/app/api/public/bookings/route.ts
+++ b/apps/admin/app/api/public/bookings/route.ts
@@ -2,8 +2,75 @@ import { BookingFormSchema, jsonError, jsonOk, parseJson } from '@repo/core';
 import { prisma } from '@repo/db';
 
 import { sendBookingConfirmation, sendBookingNotification } from '../../../lib/email';
+import type { ModifierLineItem } from '../../../lib/email';
 
 // TODO: Rate limiting — add per-IP limits when infrastructure supports it.
+
+// ── Modifier config shapes (mirrors core schemas) ─────────────────────────────
+
+type SliderCfg = { defaultValue: number; step: number; pricePerStep: number; unit: string };
+type IncrementerCfg = { defaultValue: number; pricePerUnit: number; unit?: string };
+type ToggleCfg = { defaultLabel: string; altLabel: string };
+
+type DbModifier = {
+  id: string;
+  name: string;
+  type: string;
+  isRequired: boolean;
+  priceDeltaCents: number | null;
+  config: unknown;
+};
+
+const buildModifierLineItems = (
+  modifiers: DbModifier[],
+  selectedIds: string[],
+  values: Record<string, number>
+): ModifierLineItem[] => {
+  const items: ModifierLineItem[] = [];
+
+  for (const m of modifiers) {
+    const selected = m.isRequired || selectedIds.includes(m.id);
+    if (!selected) continue;
+
+    const cfg = m.config as Record<string, unknown> | null;
+
+    if (m.type === 'SLIDER') {
+      const c = cfg as SliderCfg | null;
+      if (!c) continue;
+      const value = values[m.id] ?? c.defaultValue;
+      const steps = Math.round((value - c.defaultValue) / c.step);
+      const delta = steps * c.pricePerStep;
+      items.push({
+        name: m.name,
+        displayValue: `${value}${c.unit}`,
+        priceDeltaCents: delta || null
+      });
+    } else if (m.type === 'INCREMENTER') {
+      const c = cfg as IncrementerCfg | null;
+      if (!c) continue;
+      const count = values[m.id] ?? c.defaultValue;
+      const delta = (count - c.defaultValue) * c.pricePerUnit;
+      items.push({
+        name: m.name,
+        displayValue: `${count}${c.unit ? ` ${c.unit}` : ''}`,
+        priceDeltaCents: delta || null
+      });
+    } else if (m.type === 'TOGGLE') {
+      const c = cfg as ToggleCfg | null;
+      const altActive = selectedIds.includes(m.id);
+      items.push({
+        name: m.name,
+        displayValue: c ? (altActive ? c.altLabel : c.defaultLabel) : undefined,
+        priceDeltaCents: altActive ? (m.priceDeltaCents ?? null) : null
+      });
+    } else {
+      // CHECKBOX
+      items.push({ name: m.name, priceDeltaCents: m.priceDeltaCents ?? null });
+    }
+  }
+
+  return items;
+};
 
 export const POST = async (req: Request): Promise<Response> => {
   const result = await parseJson(req, BookingFormSchema);
@@ -23,6 +90,8 @@ export const POST = async (req: Request): Promise<Response> => {
     packageId,
     packageName,
     modifierIds,
+    modifierValues,
+    springSale,
     estimatedTotalCents
   } = result.data;
 
@@ -44,6 +113,7 @@ export const POST = async (req: Request): Promise<Response> => {
           location,
           packageName: packageName ?? null,
           modifierIds,
+          modifierValues: modifierValues ?? null,
           estimatedTotalCents: estimatedTotalCents ?? null,
           preferredDate,
           preferredTime: preferredTime ?? null
@@ -53,7 +123,7 @@ export const POST = async (req: Request): Promise<Response> => {
             packageId: packageId ?? null,
             requestedAt: isNaN(requestedAt.getTime()) ? null : requestedAt,
             notes: notes ?? null,
-            selectedOptions: { modifierIds }
+            selectedOptions: { modifierIds, modifierValues: modifierValues ?? {} }
           }
         }
       },
@@ -62,6 +132,52 @@ export const POST = async (req: Request): Promise<Response> => {
   } catch (error) {
     console.error('[bookings] Failed to persist booking request', error);
     return jsonError({ code: 'INTERNAL', message: 'Failed to save booking request.' });
+  }
+
+  // ── Build modifier line items for the email receipt ───────────────────────
+  let modifierLineItems: ModifierLineItem[] | undefined;
+
+  if (packageId) {
+    const pkgRecord = await prisma.package
+      .findUnique({
+        where: { id: packageId },
+        select: {
+          basePriceCents: true,
+          modifiers: {
+            select: {
+              id: true,
+              name: true,
+              type: true,
+              isRequired: true,
+              priceDeltaCents: true,
+              config: true
+            },
+            orderBy: { sortOrder: 'asc' }
+          }
+        }
+      })
+      .catch(() => null);
+
+    if (pkgRecord) {
+      modifierLineItems = buildModifierLineItems(
+        pkgRecord.modifiers,
+        modifierIds ?? [],
+        modifierValues ?? {}
+      );
+
+      if (springSale && estimatedTotalCents != null) {
+        const preSaleTotal =
+          (pkgRecord.basePriceCents ?? 0) +
+          modifierLineItems.reduce((sum, item) => sum + (item.priceDeltaCents ?? 0), 0);
+        const discountCents = preSaleTotal - estimatedTotalCents;
+        if (discountCents > 0) {
+          modifierLineItems.push({
+            name: 'Spring Sale (10% off)',
+            priceDeltaCents: -discountCents
+          });
+        }
+      }
+    }
   }
 
   // ── Emails ────────────────────────────────────────────────────────────────
@@ -75,7 +191,8 @@ export const POST = async (req: Request): Promise<Response> => {
     packageName: packageName ?? undefined,
     estimatedTotalCents: estimatedTotalCents ?? undefined,
     notes: notes ?? undefined,
-    inquiryId: inquiry.id
+    inquiryId: inquiry.id,
+    modifierLineItems
   };
 
   Promise.all([sendBookingConfirmation(emailData), sendBookingNotification(emailData)]).catch(

--- a/apps/admin/app/api/public/waitlist/route.ts
+++ b/apps/admin/app/api/public/waitlist/route.ts
@@ -1,0 +1,45 @@
+import { prisma } from '@repo/db';
+import { z } from 'zod';
+
+const schema = z.object({
+  email: z.string().email()
+});
+
+// Simple in-memory rate limiter: max 5 submissions per IP per hour.
+// Resets on cold start — good enough for a low-traffic waitlist.
+const attempts = new Map<string, number[]>();
+const WINDOW_MS = 60 * 60 * 1000;
+const MAX_ATTEMPTS = 5;
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const windowStart = now - WINDOW_MS;
+  const timestamps = (attempts.get(ip) ?? []).filter((t) => t > windowStart);
+  if (timestamps.length >= MAX_ATTEMPTS) return true;
+  attempts.set(ip, [...timestamps, now]);
+  return false;
+}
+
+export const POST = async (req: Request): Promise<Response> => {
+  const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
+
+  if (isRateLimited(ip)) {
+    return Response.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
+  try {
+    const body = await req.json();
+    const { email } = schema.parse(body);
+
+    await prisma.waitlistEntry.upsert({
+      where: { email },
+      create: { email },
+      update: {}
+    });
+
+    return Response.json({ ok: true });
+  } catch (err) {
+    console.error('[waitlist] error:', err);
+    return Response.json({ error: 'Invalid request' }, { status: 400 });
+  }
+};

--- a/apps/admin/app/bookings/[id]/BookingActions.tsx
+++ b/apps/admin/app/bookings/[id]/BookingActions.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { useToast } from '../../components/Toaster';
+
+const ALL_STATUSES = ['PENDING', 'REVIEWED', 'APPROVED', 'DECLINED', 'CANCELLED'] as const;
+type BookingStatus = (typeof ALL_STATUSES)[number];
+
+type Props = {
+  bookingId: string;
+  currentStatus: string;
+  emailSentAt: string | null;
+};
+
+const BookingActions = ({ bookingId, currentStatus, emailSentAt }: Props) => {
+  const router = useRouter();
+  const { addToast } = useToast();
+  const [status, setStatus] = useState<BookingStatus>(currentStatus as BookingStatus);
+  const [saving, setSaving] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const handleStatusChange = async (next: BookingStatus) => {
+    if (next === status || saving) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/bookings/${bookingId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: next })
+      });
+      if (!res.ok) throw new Error('Failed to update status');
+      setStatus(next);
+      addToast('Status updated.', 'success');
+    } catch {
+      addToast('Failed to update status.', 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleResend = async () => {
+    setResending(true);
+    try {
+      const res = await fetch(`/api/bookings/${bookingId}/resend`, { method: 'POST' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error?.message ?? 'Failed to send emails');
+      }
+      addToast('Emails sent successfully.', 'success');
+      router.refresh();
+    } catch (err) {
+      addToast(err instanceof Error ? err.message : 'Failed to send emails.', 'error');
+    } finally {
+      setResending(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/bookings/${bookingId}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to delete');
+      router.push('/bookings');
+    } catch {
+      addToast('Failed to delete booking.', 'error');
+      setDeleting(false);
+      setConfirmDelete(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-8">
+      {/* Status */}
+      <section>
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+          Status
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {ALL_STATUSES.map((s) => (
+            <button
+              key={s}
+              onClick={() => handleStatusChange(s)}
+              disabled={saving}
+              className={`rounded-md border px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 ${
+                status === s
+                  ? 'border-indigo-600 bg-indigo-600 text-white'
+                  : 'border-slate-200 text-slate-600 hover:border-slate-300 hover:bg-slate-50'
+              }`}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {/* Resend */}
+      <section>
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+          Emails
+        </h2>
+        <button
+          onClick={handleResend}
+          disabled={resending}
+          className="rounded-md border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+        >
+          {resending ? 'Sending…' : emailSentAt ? 'Resend emails' : 'Send emails'}
+        </button>
+        <p className="mt-2 text-xs text-slate-400">
+          Sends both the client confirmation and your notification email.
+        </p>
+      </section>
+
+      {/* Danger zone */}
+      <section>
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+          Danger zone
+        </h2>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleDelete}
+            disabled={deleting}
+            className={`rounded-md border px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 ${
+              confirmDelete
+                ? 'border-red-300 bg-red-50 text-red-700 hover:bg-red-100'
+                : 'border-slate-200 text-slate-600 hover:border-red-200 hover:bg-red-50 hover:text-red-600'
+            }`}
+          >
+            {deleting ? 'Deleting…' : confirmDelete ? 'Confirm delete' : 'Delete booking'}
+          </button>
+          {confirmDelete && !deleting && (
+            <button
+              onClick={() => setConfirmDelete(false)}
+              className="text-sm text-slate-400 hover:text-slate-600"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+        <p className="mt-2 text-xs text-slate-400">
+          Permanently removes the booking and its contact record.
+        </p>
+      </section>
+    </div>
+  );
+};
+
+export default BookingActions;

--- a/apps/admin/app/bookings/[id]/page.tsx
+++ b/apps/admin/app/bookings/[id]/page.tsx
@@ -1,0 +1,237 @@
+import { prisma } from '@repo/db';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { buildModifierLineItems } from '../../lib/modifiers';
+import BookingActions from './BookingActions';
+
+export const dynamic = 'force-dynamic';
+
+type BookingPayload = {
+  location?: string;
+  packageName?: string | null;
+  modifierIds?: string[];
+  modifierValues?: Record<string, number> | null;
+  estimatedTotalCents?: number | null;
+  preferredDate?: string;
+  preferredTime?: string | null;
+};
+
+type SelectedOptions = {
+  modifierIds?: string[];
+  modifierValues?: Record<string, number>;
+};
+
+const statusStyles: Record<string, string> = {
+  PENDING: 'bg-amber-50 text-amber-700 border-amber-200',
+  REVIEWED: 'bg-blue-50 text-blue-700 border-blue-200',
+  APPROVED: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  DECLINED: 'bg-red-50 text-red-700 border-red-200',
+  CANCELLED: 'bg-slate-50 text-slate-500 border-slate-200'
+};
+
+const fmt = (cents: number) =>
+  new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency: 'CAD',
+    maximumFractionDigits: 0
+  }).format(cents / 100);
+
+const fmtDelta = (cents: number | null): string => {
+  if (cents === null || cents === 0) return 'Included';
+  if (cents > 0) return `+${fmt(cents)}`;
+  return `−${fmt(Math.abs(cents))}`;
+};
+
+const BookingDetailPage = async ({ params }: { params: { id: string } }) => {
+  const booking = await prisma.bookingRequest.findUnique({
+    where: { id: params.id },
+    include: {
+      inquiry: true,
+      package: { include: { modifiers: { orderBy: { sortOrder: 'asc' } } } },
+      timeSlot: true
+    }
+  });
+
+  if (!booking) notFound();
+
+  const inquiry = booking.inquiry;
+  const payload = inquiry?.payload as BookingPayload | null;
+  const selectedOptions = booking.selectedOptions as SelectedOptions | null;
+
+  const modifierLineItems =
+    booking.package && selectedOptions
+      ? buildModifierLineItems(
+          booking.package.modifiers,
+          selectedOptions.modifierIds ?? [],
+          selectedOptions.modifierValues ?? {}
+        )
+      : null;
+
+  const emailStatus = booking.emailSentAt
+    ? {
+        label: 'Sent',
+        cls: 'text-emerald-600',
+        detail: new Date(booking.emailSentAt).toLocaleString('en-CA', {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit'
+        })
+      }
+    : booking.emailError
+      ? { label: 'Failed', cls: 'text-rose-600', detail: booking.emailError }
+      : { label: 'Not sent', cls: 'text-slate-400', detail: null };
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col gap-8 px-6 py-16">
+      <header>
+        <Link href="/bookings" className="text-sm text-slate-500 hover:text-slate-700">
+          ← Back to bookings
+        </Link>
+        <div className="mt-3 flex items-center gap-3">
+          <h1 className="text-3xl font-semibold text-slate-900">{inquiry?.name ?? 'Booking'}</h1>
+          <span
+            className={`rounded border px-2 py-0.5 text-xs font-medium ${statusStyles[booking.status] ?? ''}`}
+          >
+            {booking.status}
+          </span>
+        </div>
+        <p className="mt-1 text-sm text-slate-500">
+          Received{' '}
+          {new Date(booking.createdAt).toLocaleString('en-CA', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit'
+          })}
+        </p>
+      </header>
+
+      {/* Contact */}
+      <section>
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+          Contact
+        </h2>
+        <dl className="divide-y divide-slate-100 rounded-lg border border-slate-200 bg-white">
+          <Row label="Name" value={inquiry?.name ?? '—'} />
+          <Row
+            label="Email"
+            value={inquiry?.email ?? '—'}
+            href={inquiry?.email ? `mailto:${inquiry.email}` : undefined}
+          />
+          {inquiry?.phone && (
+            <Row label="Phone" value={inquiry.phone} href={`tel:${inquiry.phone}`} />
+          )}
+        </dl>
+      </section>
+
+      {/* Booking details */}
+      <section>
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+          Booking details
+        </h2>
+        <dl className="divide-y divide-slate-100 rounded-lg border border-slate-200 bg-white">
+          {payload?.location && <Row label="Location" value={payload.location} />}
+          {payload?.preferredDate && (
+            <Row
+              label="Preferred date"
+              value={
+                payload.preferredTime
+                  ? `${payload.preferredDate} at ${payload.preferredTime}`
+                  : payload.preferredDate
+              }
+            />
+          )}
+          {(booking.package?.name ?? payload?.packageName) && (
+            <Row label="Package" value={booking.package?.name ?? payload?.packageName ?? '—'} />
+          )}
+          {inquiry?.message && <Row label="Notes" value={inquiry.message} multiline />}
+        </dl>
+      </section>
+
+      {/* Modifier receipt */}
+      {modifierLineItems && modifierLineItems.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Package breakdown
+          </h2>
+          <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
+            <table className="w-full text-sm">
+              <tbody className="divide-y divide-slate-100">
+                {modifierLineItems.map((item, i) => (
+                  <tr key={i}>
+                    <td className="px-4 py-3 text-slate-700">{item.name}</td>
+                    <td className="px-4 py-3 text-xs text-slate-500">{item.displayValue ?? ''}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-slate-700">
+                      {fmtDelta(item.priceDeltaCents)}
+                    </td>
+                  </tr>
+                ))}
+                {payload?.estimatedTotalCents != null && (
+                  <tr className="border-t-2 border-slate-200 font-semibold">
+                    <td colSpan={2} className="px-4 py-3 text-slate-900">
+                      Estimated total
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-slate-900">
+                      {fmt(payload.estimatedTotalCents)}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {/* Email status */}
+      <section>
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+          Email status
+        </h2>
+        <div className="rounded-lg border border-slate-200 bg-white px-4 py-4">
+          <p className={`font-medium ${emailStatus.cls}`}>{emailStatus.label}</p>
+          {emailStatus.detail && (
+            <p className="mt-1 break-all text-xs text-slate-500">{emailStatus.detail}</p>
+          )}
+        </div>
+      </section>
+
+      {/* Actions */}
+      <BookingActions
+        bookingId={booking.id}
+        currentStatus={booking.status}
+        emailSentAt={booking.emailSentAt?.toISOString() ?? null}
+      />
+    </main>
+  );
+};
+
+const Row = ({
+  label,
+  value,
+  href,
+  multiline
+}: {
+  label: string;
+  value: string;
+  href?: string;
+  multiline?: boolean;
+}) => (
+  <div className="grid grid-cols-[120px_1fr] gap-4 px-4 py-3">
+    <dt className="pt-0.5 text-xs font-medium text-slate-500">{label}</dt>
+    <dd className={`text-sm text-slate-800 ${multiline ? 'whitespace-pre-wrap' : ''}`}>
+      {href ? (
+        <a href={href} className="text-indigo-600 hover:text-indigo-500">
+          {value}
+        </a>
+      ) : (
+        value
+      )}
+    </dd>
+  </div>
+);
+
+export default BookingDetailPage;

--- a/apps/admin/app/bookings/layout.tsx
+++ b/apps/admin/app/bookings/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+
+import { AdminShell } from '../components/AdminShell';
+
+const BookingsLayout = ({ children }: { children: ReactNode }) => (
+  <AdminShell>{children}</AdminShell>
+);
+
+export default BookingsLayout;

--- a/apps/admin/app/bookings/page.tsx
+++ b/apps/admin/app/bookings/page.tsx
@@ -1,0 +1,107 @@
+import { prisma } from '@repo/db';
+import Link from 'next/link';
+
+export const dynamic = 'force-dynamic';
+
+type BookingPayload = {
+  location?: string;
+  packageName?: string | null;
+  preferredDate?: string;
+  preferredTime?: string | null;
+};
+
+const statusStyles: Record<string, string> = {
+  PENDING: 'bg-amber-50 text-amber-700 border-amber-200',
+  REVIEWED: 'bg-blue-50 text-blue-700 border-blue-200',
+  APPROVED: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  DECLINED: 'bg-red-50 text-red-700 border-red-200',
+  CANCELLED: 'bg-slate-50 text-slate-500 border-slate-200'
+};
+
+const BookingsPage = async () => {
+  const bookings = await prisma.bookingRequest.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: {
+      inquiry: {
+        select: { name: true, email: true, payload: true, createdAt: true }
+      },
+      package: { select: { name: true } }
+    }
+  });
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-6 py-16">
+      <header>
+        <h1 className="text-3xl font-semibold text-slate-900">Bookings</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          {bookings.length} {bookings.length === 1 ? 'request' : 'requests'}
+        </p>
+      </header>
+
+      <div className="rounded-lg border border-slate-200 bg-white">
+        {bookings.length === 0 ? (
+          <div className="px-6 py-10 text-center text-sm text-slate-500">
+            No booking requests yet.
+          </div>
+        ) : (
+          <ul className="divide-y divide-slate-100">
+            {bookings.map((booking) => {
+              const payload = booking.inquiry?.payload as BookingPayload | null;
+
+              const emailStatus = booking.emailSentAt
+                ? { label: 'Email sent', cls: 'text-emerald-600' }
+                : booking.emailError
+                  ? { label: 'Email failed', cls: 'text-rose-600' }
+                  : { label: 'Not sent', cls: 'text-slate-400' };
+
+              return (
+                <li key={booking.id} className="flex items-center gap-4 px-6 py-4">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <p className="truncate font-semibold text-slate-900">
+                        {booking.inquiry?.name ?? '—'}
+                      </p>
+                      <span
+                        className={`shrink-0 rounded border px-1.5 py-0.5 text-xs font-medium ${statusStyles[booking.status] ?? statusStyles.PENDING}`}
+                      >
+                        {booking.status}
+                      </span>
+                    </div>
+                    <p className="truncate text-sm text-slate-500">{booking.inquiry?.email}</p>
+                  </div>
+
+                  <div className="hidden w-36 shrink-0 sm:block">
+                    <p className="truncate text-sm text-slate-700">
+                      {booking.package?.name ?? payload?.packageName ?? (
+                        <span className="text-slate-400">No package</span>
+                      )}
+                    </p>
+                  </div>
+
+                  <div className="hidden w-28 shrink-0 md:block">
+                    <p className="text-sm text-slate-700">{payload?.preferredDate ?? '—'}</p>
+                  </div>
+
+                  <div className="hidden w-24 shrink-0 lg:block">
+                    <p className={`text-xs font-medium ${emailStatus.cls}`}>{emailStatus.label}</p>
+                  </div>
+
+                  <div className="shrink-0">
+                    <Link
+                      href={`/bookings/${booking.id}`}
+                      className="text-sm font-semibold text-indigo-600 hover:text-indigo-500"
+                    >
+                      View →
+                    </Link>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+};
+
+export default BookingsPage;

--- a/apps/admin/app/components/AdminShell.tsx
+++ b/apps/admin/app/components/AdminShell.tsx
@@ -8,6 +8,7 @@ import { ToastProvider } from './Toaster';
 const navItems = [
   { label: 'Galleries', href: '/galleries' },
   { label: 'Packages', href: '/packages' },
+  { label: 'Bookings', href: '/bookings' },
   { label: 'Reviews', href: '/reviews' },
   { label: 'Availability', href: '/availability' },
   { label: 'Schedule', href: '/schedule' }

--- a/apps/admin/app/lib/email.ts
+++ b/apps/admin/app/lib/email.ts
@@ -16,6 +16,12 @@ const getResend = () => {
   return resend;
 };
 
+export type ModifierLineItem = {
+  name: string;
+  displayValue?: string;
+  priceDeltaCents: number | null;
+};
+
 type BookingEmailData = {
   name: string;
   email: string;
@@ -27,6 +33,7 @@ type BookingEmailData = {
   estimatedTotalCents?: number;
   notes?: string;
   inquiryId: string;
+  modifierLineItems?: ModifierLineItem[];
 };
 
 // ── Booking: confirmation to the client ──────────────────────────────────────

--- a/apps/admin/app/lib/modifiers.ts
+++ b/apps/admin/app/lib/modifiers.ts
@@ -1,0 +1,64 @@
+import type { ModifierLineItem } from './email';
+
+type SliderCfg = { defaultValue: number; step: number; pricePerStep: number; unit: string };
+type IncrementerCfg = { defaultValue: number; pricePerUnit: number; unit?: string };
+type ToggleCfg = { defaultLabel: string; altLabel: string };
+
+export type DbModifier = {
+  id: string;
+  name: string;
+  type: string;
+  isRequired: boolean;
+  priceDeltaCents: number | null;
+  config: unknown;
+};
+
+export const buildModifierLineItems = (
+  modifiers: DbModifier[],
+  selectedIds: string[],
+  values: Record<string, number>
+): ModifierLineItem[] => {
+  const items: ModifierLineItem[] = [];
+
+  for (const m of modifiers) {
+    const selected = m.isRequired || selectedIds.includes(m.id);
+    if (!selected) continue;
+
+    const cfg = m.config as Record<string, unknown> | null;
+
+    if (m.type === 'SLIDER') {
+      const c = cfg as SliderCfg | null;
+      if (!c) continue;
+      const value = values[m.id] ?? c.defaultValue;
+      const steps = Math.round((value - c.defaultValue) / c.step);
+      const delta = steps * c.pricePerStep;
+      items.push({
+        name: m.name,
+        displayValue: `${value}${c.unit}`,
+        priceDeltaCents: delta || null
+      });
+    } else if (m.type === 'INCREMENTER') {
+      const c = cfg as IncrementerCfg | null;
+      if (!c) continue;
+      const count = values[m.id] ?? c.defaultValue;
+      const delta = (count - c.defaultValue) * c.pricePerUnit;
+      items.push({
+        name: m.name,
+        displayValue: `${count}${c.unit ? ` ${c.unit}` : ''}`,
+        priceDeltaCents: delta || null
+      });
+    } else if (m.type === 'TOGGLE') {
+      const c = cfg as ToggleCfg | null;
+      const altActive = selectedIds.includes(m.id);
+      items.push({
+        name: m.name,
+        displayValue: c ? (altActive ? c.altLabel : c.defaultLabel) : undefined,
+        priceDeltaCents: altActive ? (m.priceDeltaCents ?? null) : null
+      });
+    } else {
+      items.push({ name: m.name, priceDeltaCents: m.priceDeltaCents ?? null });
+    }
+  }
+
+  return items;
+};

--- a/apps/admin/emails/booking-confirmation.tsx
+++ b/apps/admin/emails/booking-confirmation.tsx
@@ -1,6 +1,7 @@
 import { Text } from '@react-email/components';
 import * as React from 'react';
 
+import type { ModifierLineItem } from '../app/lib/email';
 import { EmailLayout, tokens } from './layout';
 
 type Props = {
@@ -11,6 +12,7 @@ type Props = {
   packageName?: string;
   estimatedTotalCents?: number;
   notes?: string;
+  modifierLineItems?: ModifierLineItem[];
 };
 
 const formatCurrency = (cents: number) =>
@@ -20,6 +22,12 @@ const formatCurrency = (cents: number) =>
     maximumFractionDigits: 0
   }).format(cents / 100);
 
+const formatDelta = (cents: number | null): string => {
+  if (cents === null || cents === 0) return 'Included';
+  if (cents > 0) return `+${formatCurrency(cents)}`;
+  return `−${formatCurrency(Math.abs(cents))}`;
+};
+
 export const BookingConfirmation = ({
   name,
   location,
@@ -27,10 +35,12 @@ export const BookingConfirmation = ({
   preferredTime,
   packageName,
   estimatedTotalCents,
-  notes
+  notes,
+  modifierLineItems
 }: Props) => {
   const firstName = name.split(' ')[0] ?? name;
   const dateDisplay = preferredTime ? `${preferredDate} at ${preferredTime}` : preferredDate;
+  const hasModifiers = modifierLineItems && modifierLineItems.length > 0;
 
   return (
     <EmailLayout preview="Booking request received — I'll be in touch soon.">
@@ -57,7 +67,7 @@ export const BookingConfirmation = ({
             <td style={styles.fieldLabel}>Preferred date</td>
             <td style={styles.fieldValue}>{dateDisplay}</td>
           </tr>
-          {estimatedTotalCents != null && (
+          {!hasModifiers && estimatedTotalCents != null && (
             <tr>
               <td style={styles.fieldLabel}>Est. total</td>
               <td style={styles.fieldValue}>{formatCurrency(estimatedTotalCents)}</td>
@@ -65,6 +75,31 @@ export const BookingConfirmation = ({
           )}
         </tbody>
       </table>
+
+      {hasModifiers && (
+        <>
+          <Text style={styles.sectionLabel}>Package modifiers</Text>
+          <table style={styles.modifierTable}>
+            <tbody>
+              {modifierLineItems!.map((item, i) => (
+                <tr key={i}>
+                  <td style={styles.modifierName}>{item.name}</td>
+                  <td style={styles.modifierValue}>{item.displayValue ?? ''}</td>
+                  <td style={styles.modifierPrice}>{formatDelta(item.priceDeltaCents)}</td>
+                </tr>
+              ))}
+              {estimatedTotalCents != null && (
+                <tr>
+                  <td colSpan={2} style={styles.totalLabel}>
+                    Estimated total
+                  </td>
+                  <td style={styles.totalPrice}>{formatCurrency(estimatedTotalCents)}</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </>
+      )}
 
       {notes && <Text style={styles.notes}>Your notes: {notes}</Text>}
 
@@ -83,9 +118,15 @@ BookingConfirmation.PreviewProps = {
   preferredDate: '2026-07-12',
   preferredTime: '10:00',
   packageName: 'Full Day',
-  estimatedTotalCents: 95000,
-  notes: 'Looking for a mix of candid and a few posed shots in the park.'
-};
+  estimatedTotalCents: 85500,
+  notes: 'Looking for a mix of candid and a few posed shots in the park.',
+  modifierLineItems: [
+    { name: 'Session length', displayValue: '4 hr', priceDeltaCents: null },
+    { name: 'Studio backdrop', priceDeltaCents: 7500 },
+    { name: 'Rush editing', displayValue: 'Rush (7 days)', priceDeltaCents: 15000 },
+    { name: 'Spring Sale (10% off)', priceDeltaCents: -10500 }
+  ]
+} satisfies Props;
 
 export default BookingConfirmation;
 
@@ -134,6 +175,63 @@ const styles = {
     fontFamily: "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
     paddingBottom: '8px',
     verticalAlign: 'top' as const
+  },
+  sectionLabel: {
+    color: tokens.inkFaint,
+    fontSize: '11px',
+    fontFamily: "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    letterSpacing: '0.08em',
+    margin: '0 0 12px',
+    textTransform: 'uppercase' as const
+  },
+  modifierTable: {
+    borderCollapse: 'collapse' as const,
+    marginBottom: '24px',
+    width: '100%'
+  },
+  modifierName: {
+    color: tokens.inkMuted,
+    fontSize: '13px',
+    fontFamily: "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    paddingBottom: '7px',
+    paddingRight: '16px',
+    verticalAlign: 'top' as const
+  },
+  modifierValue: {
+    color: tokens.inkFaint,
+    fontSize: '13px',
+    fontFamily: "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    paddingBottom: '7px',
+    paddingRight: '16px',
+    verticalAlign: 'top' as const,
+    width: '100px'
+  },
+  modifierPrice: {
+    color: tokens.inkMuted,
+    fontSize: '13px',
+    fontFamily: "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    paddingBottom: '7px',
+    textAlign: 'right' as const,
+    verticalAlign: 'top' as const,
+    whiteSpace: 'nowrap' as const
+  },
+  totalLabel: {
+    borderTop: `1px solid ${tokens.border}`,
+    color: tokens.ink,
+    fontSize: '13px',
+    fontFamily: "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    fontWeight: '600',
+    paddingTop: '10px'
+  },
+  totalPrice: {
+    borderTop: `1px solid ${tokens.border}`,
+    color: tokens.ink,
+    fontSize: '13px',
+    fontFamily: "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    fontWeight: '600',
+    paddingTop: '10px',
+    textAlign: 'right' as const,
+    whiteSpace: 'nowrap' as const
   },
   notes: {
     backgroundColor: tokens.canvas,

--- a/apps/admin/emails/booking-notification.tsx
+++ b/apps/admin/emails/booking-notification.tsx
@@ -1,6 +1,7 @@
 import { Link, Text } from '@react-email/components';
 import * as React from 'react';
 
+import type { ModifierLineItem } from '../app/lib/email';
 import { EmailLayout, tokens } from './layout';
 
 type Props = {
@@ -14,6 +15,7 @@ type Props = {
   estimatedTotalCents?: number;
   notes?: string;
   inquiryId: string;
+  modifierLineItems?: ModifierLineItem[];
 };
 
 const formatCurrency = (cents: number) =>
@@ -22,6 +24,12 @@ const formatCurrency = (cents: number) =>
     currency: 'CAD',
     maximumFractionDigits: 0
   }).format(cents / 100);
+
+const formatDelta = (cents: number | null): string => {
+  if (cents === null || cents === 0) return 'Included';
+  if (cents > 0) return `+${formatCurrency(cents)}`;
+  return `−${formatCurrency(Math.abs(cents))}`;
+};
 
 export const BookingNotification = ({
   name,
@@ -33,9 +41,11 @@ export const BookingNotification = ({
   packageName,
   estimatedTotalCents,
   notes,
-  inquiryId
+  inquiryId,
+  modifierLineItems
 }: Props) => {
   const dateDisplay = preferredTime ? `${preferredDate} at ${preferredTime}` : preferredDate;
+  const hasModifiers = modifierLineItems && modifierLineItems.length > 0;
 
   return (
     <EmailLayout preview={`New booking request — ${packageName ?? 'no package'} — ${name}`}>
@@ -76,7 +86,7 @@ export const BookingNotification = ({
             <td style={styles.fieldLabel}>Preferred date</td>
             <td style={styles.fieldValue}>{dateDisplay}</td>
           </tr>
-          {estimatedTotalCents != null && (
+          {!hasModifiers && estimatedTotalCents != null && (
             <tr>
               <td style={styles.fieldLabel}>Est. total</td>
               <td style={styles.fieldValue}>{formatCurrency(estimatedTotalCents)}</td>
@@ -88,6 +98,31 @@ export const BookingNotification = ({
           </tr>
         </tbody>
       </table>
+
+      {hasModifiers && (
+        <>
+          <Text style={styles.sectionLabel}>Package modifiers</Text>
+          <table style={styles.modifierTable}>
+            <tbody>
+              {modifierLineItems!.map((item, i) => (
+                <tr key={i}>
+                  <td style={styles.modifierName}>{item.name}</td>
+                  <td style={styles.modifierValue}>{item.displayValue ?? ''}</td>
+                  <td style={styles.modifierPrice}>{formatDelta(item.priceDeltaCents)}</td>
+                </tr>
+              ))}
+              {estimatedTotalCents != null && (
+                <tr>
+                  <td colSpan={2} style={styles.totalLabel}>
+                    Estimated total
+                  </td>
+                  <td style={styles.totalPrice}>{formatCurrency(estimatedTotalCents)}</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </>
+      )}
 
       {notes && (
         <>
@@ -109,10 +144,16 @@ BookingNotification.PreviewProps = {
   preferredDate: '2026-07-12',
   preferredTime: '10:00',
   packageName: 'Full Day',
-  estimatedTotalCents: 95000,
+  estimatedTotalCents: 85500,
   notes: 'Looking for a mix of candid and a few posed shots in the park.',
-  inquiryId: 'clz1abc2def3ghi4'
-};
+  inquiryId: 'clz1abc2def3ghi4',
+  modifierLineItems: [
+    { name: 'Session length', displayValue: '4 hr', priceDeltaCents: null },
+    { name: 'Studio backdrop', priceDeltaCents: 7500 },
+    { name: 'Rush editing', displayValue: 'Rush (7 days)', priceDeltaCents: 15000 },
+    { name: 'Spring Sale (10% off)', priceDeltaCents: -10500 }
+  ]
+} satisfies Props;
 
 export default BookingNotification;
 
@@ -158,6 +199,63 @@ const styles = {
   link: {
     color: tokens.accent,
     textDecoration: 'none'
+  },
+  sectionLabel: {
+    color: tokens.inkFaint,
+    fontSize: '11px',
+    fontFamily: "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    letterSpacing: '0.08em',
+    margin: '0 0 12px',
+    textTransform: 'uppercase' as const
+  },
+  modifierTable: {
+    borderCollapse: 'collapse' as const,
+    marginBottom: '28px',
+    width: '100%'
+  },
+  modifierName: {
+    color: tokens.inkMuted,
+    fontSize: '13px',
+    fontFamily: "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    paddingBottom: '7px',
+    paddingRight: '16px',
+    verticalAlign: 'top' as const
+  },
+  modifierValue: {
+    color: tokens.inkFaint,
+    fontSize: '13px',
+    fontFamily: "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    paddingBottom: '7px',
+    paddingRight: '16px',
+    verticalAlign: 'top' as const,
+    width: '100px'
+  },
+  modifierPrice: {
+    color: tokens.inkMuted,
+    fontSize: '13px',
+    fontFamily: "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    paddingBottom: '7px',
+    textAlign: 'right' as const,
+    verticalAlign: 'top' as const,
+    whiteSpace: 'nowrap' as const
+  },
+  totalLabel: {
+    borderTop: `1px solid ${tokens.border}`,
+    color: tokens.ink,
+    fontSize: '13px',
+    fontFamily: "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    fontWeight: '600',
+    paddingTop: '10px'
+  },
+  totalPrice: {
+    borderTop: `1px solid ${tokens.border}`,
+    color: tokens.ink,
+    fontSize: '13px',
+    fontFamily: "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    fontWeight: '600',
+    paddingTop: '10px',
+    textAlign: 'right' as const,
+    whiteSpace: 'nowrap' as const
   },
   notesLabel: {
     color: tokens.inkFaint,

--- a/apps/evrydayarchive-web/app/api/waitlist/route.ts
+++ b/apps/evrydayarchive-web/app/api/waitlist/route.ts
@@ -1,45 +1,27 @@
-import { prisma } from '@repo/db';
-import { z } from 'zod';
+import { getServerEnv } from '../../lib/env';
 
-const schema = z.object({
-  email: z.string().email()
-});
+export const POST = async (req: Request): Promise<Response> => {
+  const { ADMIN_API_BASE_URL } = getServerEnv();
 
-// Simple in-memory rate limiter: max 5 submissions per IP per hour.
-// Good enough for a low-traffic coming-soon page; resets on cold start.
-const attempts = new Map<string, number[]>();
-const WINDOW_MS = 60 * 60 * 1000;
-const MAX_ATTEMPTS = 5;
-
-function isRateLimited(ip: string): boolean {
-  const now = Date.now();
-  const windowStart = now - WINDOW_MS;
-  const timestamps = (attempts.get(ip) ?? []).filter((t) => t > windowStart);
-  if (timestamps.length >= MAX_ATTEMPTS) return true;
-  attempts.set(ip, [...timestamps, now]);
-  return false;
-}
-
-export async function POST(req: Request) {
-  const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
-
-  if (isRateLimited(ip)) {
-    return Response.json({ error: 'Too many requests' }, { status: 429 });
-  }
-
+  let body: unknown;
   try {
-    const body = await req.json();
-    const { email } = schema.parse(body);
-
-    await prisma.waitlistEntry.upsert({
-      where: { email },
-      create: { email },
-      update: {}
-    });
-
-    return Response.json({ ok: true });
-  } catch (err) {
-    console.error('[waitlist] error:', err);
+    body = await req.json();
+  } catch {
     return Response.json({ error: 'Invalid request' }, { status: 400 });
   }
-}
+
+  let adminRes: Response;
+  try {
+    adminRes = await fetch(new URL('/api/public/waitlist', ADMIN_API_BASE_URL), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+  } catch (err) {
+    console.error('[waitlist] Failed to reach admin API', err);
+    return Response.json({ error: 'Unable to submit. Please try again.' }, { status: 502 });
+  }
+
+  const data = await adminRes.json().catch(() => null);
+  return Response.json(data, { status: adminRes.status });
+};

--- a/apps/evrydayarchive-web/app/book/booking-form.tsx
+++ b/apps/evrydayarchive-web/app/book/booking-form.tsx
@@ -251,6 +251,7 @@ export const BookingForm = ({
       packageName: pkg?.name,
       modifierIds: resolvedModifiers.filter((m) => !m.isRequired).map((m) => m.id),
       modifierValues: Object.keys(modifierValues).length > 0 ? modifierValues : undefined,
+      springSale: springSale || undefined,
       // Reflects the discounted total when Spring Sale is active so the booking record
       // shows what the customer was actually quoted.
       estimatedTotalCents: effectiveTotalCents

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ci": "vitest run --coverage",
-    "db-schema:generate": "pnpm --filter @repo/db db:generate",
-    "db-schema:migrate": "pnpm --filter @repo/db db:migrate",
-    "db-schema:deploy": "pnpm --filter @repo/db db:deploy",
-    "db-schema:update": "pnpm db-schema:generate && pnpm db-schema:migrate"
+    "db:migrate": "pnpm --filter @repo/db db:migrate",
+    "db:deploy": "pnpm --filter @repo/db db:deploy",
+    "db:status": "pnpm --filter @repo/db db:status",
+    "db:studio": "pnpm --filter @repo/db db:studio"
   },
   "devDependencies": {
     "@types/node": "20.14.2",

--- a/packages/core/src/schemas/booking-form.ts
+++ b/packages/core/src/schemas/booking-form.ts
@@ -14,6 +14,8 @@ export const BookingFormSchema = z.object({
   packageId: z.string().optional(),
   packageName: z.string().optional(),
   modifierIds: z.array(z.string()).default([]),
+  modifierValues: z.record(z.number()).optional(),
+  springSale: z.boolean().optional(),
   estimatedTotalCents: z.number().int().nonnegative().optional()
 });
 

--- a/packages/core/src/schemas/booking-request.ts
+++ b/packages/core/src/schemas/booking-request.ts
@@ -15,3 +15,17 @@ export const BookingRequestSubmissionPayloadSchema = z.object({
 });
 
 export type BookingRequestSubmissionPayload = z.infer<typeof BookingRequestSubmissionPayloadSchema>;
+
+export const BookingRequestStatusValues = [
+  'PENDING',
+  'REVIEWED',
+  'APPROVED',
+  'DECLINED',
+  'CANCELLED'
+] as const;
+
+export const BookingRequestUpdateSchema = z.object({
+  status: z.enum(BookingRequestStatusValues).optional()
+});
+
+export type BookingRequestUpdate = z.infer<typeof BookingRequestUpdateSchema>;

--- a/packages/db/prisma/migrations/20260515194512_add_booking_email_status/migration.sql
+++ b/packages/db/prisma/migrations/20260515194512_add_booking_email_status/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "BookingRequest" ADD COLUMN     "emailError" TEXT,
+ADD COLUMN     "emailSentAt" TIMESTAMP(3);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -223,6 +223,8 @@ model BookingRequest {
   requestedAt     DateTime?
   notes           String?
   selectedOptions Json?
+  emailSentAt     DateTime?
+  emailError      String?
   createdAt       DateTime             @default(now())
   updatedAt       DateTime             @updatedAt
   inquiry         Inquiry?             @relation(fields: [inquiryId], references: [id], onDelete: SetNull)

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,22 +1,13 @@
 import { PrismaClient } from '@prisma/client';
 
-import { getDbEnv } from './env';
-
 const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient;
 };
 
-const { DATABASE_URL } = getDbEnv();
-
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
-    log: ['error', 'warn'],
-    datasources: {
-      db: {
-        url: DATABASE_URL
-      }
-    }
+    log: ['error', 'warn']
   });
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,5 +1,4 @@
 export { prisma } from './client';
-export { getDbEnv } from './env';
 export type {
   BookingRequest,
   BookingRequestStatus,


### PR DESCRIPTION
## Summary

This PR originally added receipt-style modifier breakdowns to booking emails. It has since expanded to include an admin bookings dashboard, email delivery reliability fixes, DB/env architecture cleanup, standardized scripts, a README rewrite, an automated migration step in the release CI workflow, and a fix for a module-load crash in the waitlist API.

---

### 1. Receipt-style modifier breakdown in emails

Booking confirmation and notification emails now show an itemized **Package modifiers** section — each selected modifier with its display value (e.g. "4 hr", "2 outfits") and price impact ("+$75", "Included", "−$95"). The estimated total moves into this section as a receipt-style total row when modifiers are present. The Spring Sale discount appears as an explicit line item when active.

Also fixes two data-loss bugs from the original schema: `modifierValues` and `springSale` were being stripped at validation and never reached the server. Both are now persisted to the DB and used to compute the breakdown.

**Affected files:**
- `apps/admin/emails/booking-confirmation.tsx`
- `apps/admin/emails/booking-notification.tsx`
- `apps/admin/app/api/public/bookings/route.ts`
- `apps/evrydayarchive-web/app/book/booking-form.tsx`
- `packages/core/src/schemas/booking-form.ts`

---

### 2. Admin bookings dashboard + email status tracking

**Problem:** Booking requests were being persisted to the DB but there was no admin UI to view them, no way to see if emails succeeded or failed, and no way to act on incoming requests.

#### DB schema change (migration applied to development branch)
- `BookingRequest.emailSentAt DateTime?` — set when both emails send successfully
- `BookingRequest.emailError String?` — set when email sending throws

#### Email sending fix (reliability)
Previously, emails were sent via fire-and-forget. In a serverless environment the process can be killed before emails complete, with no record of the failure. Emails are now awaited and the result persisted to the DB. **This is the most likely cause of previously missing booking emails.**

#### Admin API routes (all require admin session cookie)
- `GET /api/bookings` — list all booking requests
- `GET /api/bookings/[id]` — full detail with package and modifier data
- `PATCH /api/bookings/[id]` — update booking status (PENDING -> REVIEWED -> APPROVED / DECLINED / CANCELLED)
- `DELETE /api/bookings/[id]` — deletes both the BookingRequest and its linked Inquiry in a transaction
- `POST /api/bookings/[id]/resend` — re-sends both client confirmation and notification emails; updates emailSentAt / emailError

#### Admin pages
- `/bookings` — list view: name, email, package, preferred date, email status badge, link to detail
- `/bookings/[id]` — detail view: contact info, booking details, package modifier receipt (reconstructed from DB), email status, interactive status buttons, resend button, two-click delete

#### Other
- `apps/admin/app/lib/modifiers.ts` — extracted `buildModifierLineItems` into a shared helper
- `packages/core/src/schemas/booking-request.ts` — added `BookingRequestUpdateSchema` and `BookingRequestStatusValues`
- `apps/admin/app/components/AdminShell.tsx` — added **Bookings** nav item between Packages and Reviews

**Affected files:**
- `packages/db/prisma/schema.prisma` + migration
- `packages/core/src/schemas/booking-request.ts`
- `apps/admin/app/api/public/bookings/route.ts` (modified)
- `apps/admin/app/api/bookings/route.ts` (new)
- `apps/admin/app/api/bookings/[id]/route.ts` (new)
- `apps/admin/app/api/bookings/[id]/resend/route.ts` (new)
- `apps/admin/app/lib/modifiers.ts` (new)
- `apps/admin/app/bookings/layout.tsx` (new)
- `apps/admin/app/bookings/page.tsx` (new)
- `apps/admin/app/bookings/[id]/page.tsx` (new)
- `apps/admin/app/bookings/[id]/BookingActions.tsx` (new)
- `apps/admin/app/components/AdminShell.tsx` (modified)

---

### 3. DB/env architecture cleanup + README rewrite

Clarified and standardized the database connection setup across the monorepo:

- **One Neon project, two branches** (`production` and `development`) — the development project was a mistake and should be removed.
- **Two roles per branch:** `neondb_owner` for migrations (DDL), `local_development` / Vercel app role for runtime (DML only).
- `packages/db/.env` uses `neondb_owner` — required for `prisma migrate deploy` to run ALTER TABLE.
- `apps/admin/.env` uses `local_development` — restricted role limits blast radius if credentials are exposed.
- **Vercel:** `DATABASE_URL` is now scoped per environment — production points to Neon `production` branch, preview/development points to Neon `development` branch.
- Renamed confusingly prefixed `db-schema:*` root scripts to `db:migrate`, `db:deploy`, `db:status`, `db:studio`.
- README Database and environment variable sections fully rewritten to match the above.

**Affected files:**
- `README.md`
- `package.json` (root) — script renames

---

### 4. Automated production migrations in release CI

The `release-to-production.yml` GitHub Actions workflow now runs `pnpm db:deploy` against the production Neon branch **before** fast-forwarding the `production` git branch (which triggers the Vercel deploy). This guarantees the DB schema is always ready before the new code goes live.

Requires a `DATABASE_PROD_OWNER_URL` secret in the GitHub repo — the `neondb_owner` connection string for the Neon `production` branch. **This secret must be added before the next release.**

**Affected files:**
- `.github/workflows/release-to-production.yml`

---

### 5. Fix: waitlist API crash on module load

**Problem:** `evrydayarchive-web/app/api/waitlist/route.ts` imported `prisma` directly from `@repo/db`. The db package validates `DATABASE_URL` via Zod at module load time — so any route importing `prisma` would throw a Zod `invalid_type` error and crash if `DATABASE_URL` wasn't set in that Vercel project. Since `evrydayarchive-web` doesn't connect to the DB directly (it goes through the admin API), `DATABASE_URL` was never configured there.

**Fix:** Moved the waitlist DB logic (upsert + rate limiter) to a new `admin/app/api/public/waitlist/route.ts`, consistent with all other public DB-backed endpoints. The `evrydayarchive-web` route is now a thin proxy to `ADMIN_API_BASE_URL/api/public/waitlist`, matching the pattern used by `/api/bookings`, `/api/galleries`, etc.

**Affected files:**
- `apps/admin/app/api/public/waitlist/route.ts` (new)
- `apps/evrydayarchive-web/app/api/waitlist/route.ts` (rewritten to proxy)

---

## Test plan

### Email receipt
- [ ] Submit a booking via `/book` with a package and modifiers selected
- [ ] Confirm the client confirmation email shows the modifier breakdown table (name | display value | +/− price) with an estimated total row
- [ ] Confirm the admin notification email shows the same breakdown
- [ ] Submit a booking with no package — confirm emails render cleanly without the modifiers section
- [ ] Submit a booking with Spring Sale active on a May date — confirm the discount appears as a named line item

### Email delivery fix
- [ ] Submit a booking and confirm it appears in `/bookings` with **Email sent** status (green) and a sent timestamp on the detail page
- [ ] If RESEND_API_KEY or NOTIFICATION_EMAIL are wrong/missing, confirm the detail page shows **Email failed** with the error message

### Admin bookings list (`/bookings`)
- [ ] Bookings appear sorted newest-first
- [ ] Each row shows: name, email, package name (or "No package"), preferred date, email status badge
- [ ] Empty state renders cleanly when no bookings exist

### Admin booking detail (`/bookings/[id]`)
- [ ] Contact section: name, email (clickable mailto), phone (if provided)
- [ ] Package breakdown section: modifier table with delta column and estimated total row (only shown when modifiers are present)
- [ ] Email status section: shows "Sent" + timestamp, "Failed" + error, or "Not sent"
- [ ] Status buttons: update status correctly; active status is highlighted
- [ ] Resend: sends both emails, refreshes email status section, shows toast
- [ ] Delete: two-click confirm deletes booking + contact record, redirects to `/bookings`
- [ ] Non-existent booking ID returns 404

### Nav
- [ ] "Bookings" appears in the admin sidebar between Packages and Reviews

### Waitlist
- [ ] Submit an email on the coming-soon/waitlist form — confirm it's saved in the DB and returns `{ ok: true }`
- [ ] Submit the same email again — confirm it returns `{ ok: true }` without error (upsert, not insert)
- [ ] Submit an invalid email — confirm 400 response

---

## Risk / rollback notes

**Risk level:** Medium

**Main risks:**
- Email send is now awaited before returning the booking success response — adds ~1–2s to the `/book` form submission.
- The Prisma migration adds two nullable columns to `BookingRequest` — non-destructive.
- `DELETE /api/bookings/[id]` removes both BookingRequest and linked Inquiry in a transaction — irreversible.
- Release workflow now runs migrations before deploying — requires `DATABASE_PROD_OWNER_URL` secret to be set or the workflow will fail.

**Rollback:** Revert the commits on this branch. The migration columns are nullable so the app continues to function without them — no down migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
