### PR TITLE
SEO: structured data, canonical URLs, and www consistency

### DIFF
--- a/apps/evrydayarchive-web/app/about/page.tsx
+++ b/apps/evrydayarchive-web/app/about/page.tsx
@@ -176,7 +176,7 @@ const ArchiveGrid = ({ mobile }: { mobile: boolean }) => {
 export const metadata: Metadata = {
   title: 'About | Evryday Archive Co',
   description:
-    'Meet Reed McIlwain, the photographer behind Evryday Archive Co — documenting ordinary life as something worth keeping in Kamloops and Vancouver Island.',
+    'Meet Reed McIlwain, the photographer behind Evryday Archive Co — a BC photographer based in Kamloops, documenting ordinary life as something worth keeping.',
   alternates: { canonical: '/about' }
 };
 

--- a/apps/evrydayarchive-web/app/about/page.tsx
+++ b/apps/evrydayarchive-web/app/about/page.tsx
@@ -176,7 +176,8 @@ const ArchiveGrid = ({ mobile }: { mobile: boolean }) => {
 export const metadata: Metadata = {
   title: 'About | Evryday Archive Co',
   description:
-    'Meet Reed McIlwain, the photographer behind Evryday Archive Co — documenting ordinary life as something worth keeping in Kamloops and Vancouver Island.'
+    'Meet Reed McIlwain, the photographer behind Evryday Archive Co — documenting ordinary life as something worth keeping in Kamloops and Vancouver Island.',
+  alternates: { canonical: '/about' }
 };
 
 // ── Page ──────────────────────────────────────────────────────────────────────

--- a/apps/evrydayarchive-web/app/book/page.tsx
+++ b/apps/evrydayarchive-web/app/book/page.tsx
@@ -20,7 +20,8 @@ import { BookingForm } from './booking-form';
 export const metadata: Metadata = {
   title: 'Book a Session | Evryday Archive Co',
   description: 'Request your photography session with Evryday Archive Co.',
-  robots: { index: false }
+  robots: { index: false },
+  alternates: { canonical: '/book' }
 };
 
 export const dynamic = 'force-dynamic';

--- a/apps/evrydayarchive-web/app/components/site-footer.tsx
+++ b/apps/evrydayarchive-web/app/components/site-footer.tsx
@@ -23,7 +23,7 @@ export const SiteFooter = () => {
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img src="/logo/icon.svg" alt="" className="mx-auto h-8 w-auto sm:mx-0" />
             <p className="text-sm font-semibold text-ink">Evryday Archive Co</p>
-            <p className="text-xs text-ink-faint">Documenting life in Kamloops & BC</p>
+            <p className="text-xs text-ink-faint">Documenting life across BC</p>
           </div>
 
           {/* Email capture — mobile: order 2 | desktop: col 3 row 1 */}

--- a/apps/evrydayarchive-web/app/contact/page.tsx
+++ b/apps/evrydayarchive-web/app/contact/page.tsx
@@ -5,7 +5,8 @@ import { ContactForm } from './contact-form';
 export const metadata: Metadata = {
   title: 'Contact | Evryday Archive Co',
   description:
-    'Get in touch with Evryday Archive Co. Reach out with questions, inquiries, or to start planning your photography session with Reed McIlwain.'
+    'Get in touch with Evryday Archive Co. Reach out with questions, inquiries, or to start planning your photography session with Reed McIlwain.',
+  alternates: { canonical: '/contact' }
 };
 
 const ContactPage = () => {

--- a/apps/evrydayarchive-web/app/faq/page.tsx
+++ b/apps/evrydayarchive-web/app/faq/page.tsx
@@ -54,7 +54,8 @@ const FAQ_ITEMS = [
 export const metadata: Metadata = {
   title: 'FAQs | Evryday Archive Co',
   description:
-    'Answers to common questions about booking, pricing, turnaround time, and what to expect from your Evryday Archive session.'
+    'Answers to common questions about booking, pricing, turnaround time, and what to expect from your Evryday Archive session.',
+  alternates: { canonical: '/faq' }
 };
 
 const FaqPage = () => {

--- a/apps/evrydayarchive-web/app/inquire/page.tsx
+++ b/apps/evrydayarchive-web/app/inquire/page.tsx
@@ -9,7 +9,8 @@ import { Questionnaire } from './questionnaire';
 export const metadata: Metadata = {
   title: 'Get Started | Evryday Archive Co',
   description:
-    'Tell us about yourself and get a tailored session recommendation. Start planning your Evryday Archive photography session today.'
+    'Tell us about yourself and get a tailored session recommendation. Start planning your Evryday Archive photography session today.',
+  alternates: { canonical: '/inquire' }
 };
 
 export const dynamic = 'force-dynamic';

--- a/apps/evrydayarchive-web/app/layout.tsx
+++ b/apps/evrydayarchive-web/app/layout.tsx
@@ -93,6 +93,24 @@ const jsonLd = {
         name: 'British Columbia',
         containedInPlace: { '@type': 'Country', name: 'Canada' }
       }
+    },
+    {
+      '@type': 'City',
+      name: 'Victoria',
+      containedInPlace: {
+        '@type': 'AdministrativeArea',
+        name: 'British Columbia',
+        containedInPlace: { '@type': 'Country', name: 'Canada' }
+      }
+    },
+    {
+      '@type': 'City',
+      name: 'Vancouver',
+      containedInPlace: {
+        '@type': 'AdministrativeArea',
+        name: 'British Columbia',
+        containedInPlace: { '@type': 'Country', name: 'Canada' }
+      }
     }
   ],
   sameAs: ['https://www.instagram.com/evrydayarchive.co/']

--- a/apps/evrydayarchive-web/app/layout.tsx
+++ b/apps/evrydayarchive-web/app/layout.tsx
@@ -55,8 +55,9 @@ export const metadata: Metadata = {
 
 const jsonLd = {
   '@context': 'https://schema.org',
-  '@type': 'ProfessionalService',
+  '@type': 'LocalBusiness',
   name: 'Evryday Archive Co',
+  alternateName: 'Everyday Archive Co',
   logo: {
     '@type': 'ImageObject',
     url: 'https://evrydayarchive.co/logo/og-image-square.png',
@@ -67,42 +68,28 @@ const jsonLd = {
     '@type': 'Person',
     name: 'Reed McIlwain'
   },
+  employee: {
+    '@type': 'Person',
+    name: 'Reed McIlwain'
+  },
   description:
     'Kamloops & Vancouver Island photographer documenting ordinary life as something worth keeping. Accessible sessions, transparent pricing.',
-  url: 'https://evrydayarchive.co',
+  url: 'https://www.evrydayarchive.co',
   areaServed: [
     {
       '@type': 'City',
       name: 'Kamloops',
       containedInPlace: {
-        '@type': 'State',
+        '@type': 'AdministrativeArea',
         name: 'British Columbia',
         containedInPlace: { '@type': 'Country', name: 'Canada' }
       }
     },
     {
-      '@type': 'City',
-      name: 'Vancouver',
+      '@type': 'AdministrativeArea',
+      name: 'Vancouver Island',
       containedInPlace: {
-        '@type': 'State',
-        name: 'British Columbia',
-        containedInPlace: { '@type': 'Country', name: 'Canada' }
-      }
-    },
-    {
-      '@type': 'City',
-      name: 'Victoria',
-      containedInPlace: {
-        '@type': 'State',
-        name: 'British Columbia',
-        containedInPlace: { '@type': 'Country', name: 'Canada' }
-      }
-    },
-    {
-      '@type': 'City',
-      name: 'Nanaimo',
-      containedInPlace: {
-        '@type': 'State',
+        '@type': 'AdministrativeArea',
         name: 'British Columbia',
         containedInPlace: { '@type': 'Country', name: 'Canada' }
       }

--- a/apps/evrydayarchive-web/app/layout.tsx
+++ b/apps/evrydayarchive-web/app/layout.tsx
@@ -36,19 +36,12 @@ export const metadata: Metadata = {
   },
   openGraph: {
     type: 'website',
-    url: 'https://evrydayarchive.co',
-    title: 'Evryday Archive Co | Reed McIlwain, Photographer',
-    description:
-      'Kamloops & Vancouver Island photographer documenting ordinary life as something worth keeping. Accessible sessions, transparent pricing.',
     locale: 'en_CA',
     siteName: 'Evryday Archive Co',
     images: [{ url: '/logo/og-image.jpg', width: 1200, height: 630 }]
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Evryday Archive Co | Reed McIlwain, Photographer',
-    description:
-      'Kamloops & Vancouver Island photographer documenting ordinary life as something worth keeping. Accessible sessions, transparent pricing.',
     images: ['/logo/og-image.jpg']
   }
 };

--- a/apps/evrydayarchive-web/app/layout.tsx
+++ b/apps/evrydayarchive-web/app/layout.tsx
@@ -26,7 +26,7 @@ const jetBrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://evrydayarchive.co'),
+  metadataBase: new URL('https://www.evrydayarchive.co'),
   title: 'Evryday Archive Co | Reed McIlwain, Photographer',
   description:
     'Kamloops & Vancouver Island photographer documenting ordinary life as something worth keeping. Accessible sessions, transparent pricing.',

--- a/apps/evrydayarchive-web/app/layout.tsx
+++ b/apps/evrydayarchive-web/app/layout.tsx
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://www.evrydayarchive.co'),
   title: 'Evryday Archive Co | Reed McIlwain, Photographer',
   description:
-    'Kamloops & Vancouver Island photographer documenting ordinary life as something worth keeping. Accessible sessions, transparent pricing.',
+    'BC photographer based in Kamloops — documenting ordinary life as something worth keeping. Accessible sessions, transparent pricing.',
   icons: {
     icon: [{ url: '/logo/icon-square.png', sizes: '512x512', type: 'image/png' }],
     apple: '/logo/icon-square.png'
@@ -66,7 +66,7 @@ const jsonLd = {
     name: 'Reed McIlwain'
   },
   description:
-    'Kamloops & Vancouver Island photographer documenting ordinary life as something worth keeping. Accessible sessions, transparent pricing.',
+    'BC photographer based in Kamloops — documenting ordinary life as something worth keeping. Accessible sessions, transparent pricing.',
   url: 'https://www.evrydayarchive.co',
   areaServed: [
     {

--- a/apps/evrydayarchive-web/app/lib/hero-copy.ts
+++ b/apps/evrydayarchive-web/app/lib/hero-copy.ts
@@ -9,7 +9,7 @@ export type HeroTextVariant = {
 
 export const HERO_TEXT_VARIANTS: HeroTextVariant[] = [
   {
-    eyebrow: 'Kamloops · BC',
+    eyebrow: 'Kamloops · Victoria · Vancouver',
     heading: 'Your everyday life\nis worth documenting.',
     body: "Most people wait for a milestone. You don't have to. Sessions shaped around who you actually are, right now."
   },

--- a/apps/evrydayarchive-web/app/lib/hero-copy.ts
+++ b/apps/evrydayarchive-web/app/lib/hero-copy.ts
@@ -9,7 +9,7 @@ export type HeroTextVariant = {
 
 export const HERO_TEXT_VARIANTS: HeroTextVariant[] = [
   {
-    eyebrow: 'Kamloops · Vancouver Island',
+    eyebrow: 'Kamloops · BC',
     heading: 'Your everyday life\nis worth documenting.',
     body: "Most people wait for a milestone. You don't have to. Sessions shaped around who you actually are, right now."
   },

--- a/apps/evrydayarchive-web/app/manifest.ts
+++ b/apps/evrydayarchive-web/app/manifest.ts
@@ -5,7 +5,7 @@ export default function manifest(): MetadataRoute.Manifest {
     name: 'Evryday Archive Co',
     short_name: 'Evryday Archive',
     description:
-      'Kamloops & Vancouver Island photographer documenting ordinary life as something worth keeping.',
+      'BC photographer based in Kamloops, documenting ordinary life as something worth keeping.',
     start_url: '/',
     display: 'browser',
     background_color: '#f7f4ef',

--- a/apps/evrydayarchive-web/app/package-builder/page.tsx
+++ b/apps/evrydayarchive-web/app/package-builder/page.tsx
@@ -9,7 +9,8 @@ import { BuilderCard } from './builder-card';
 export const metadata: Metadata = {
   title: 'Build Your Package | Evryday Archive Co',
   description:
-    'Customize your photography session from the ground up. Mix and match add-ons to build a package that fits your vision and budget.'
+    'Customize your photography session from the ground up. Mix and match add-ons to build a package that fits your vision and budget.',
+  alternates: { canonical: '/package-builder' }
 };
 
 export const dynamic = 'force-dynamic';

--- a/apps/evrydayarchive-web/app/packages/page.tsx
+++ b/apps/evrydayarchive-web/app/packages/page.tsx
@@ -8,7 +8,8 @@ import { getServerEnv } from '../lib/env';
 export const metadata: Metadata = {
   title: 'Photography Packages | Evryday Archive Co',
   description:
-    'Transparent session pricing with no hidden fees. Browse photography packages and find the right fit for your budget and occasion.'
+    'Transparent session pricing with no hidden fees. Browse photography packages and find the right fit for your budget and occasion.',
+  alternates: { canonical: '/packages' }
 };
 
 export const dynamic = 'force-dynamic';

--- a/apps/evrydayarchive-web/app/page.tsx
+++ b/apps/evrydayarchive-web/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import Image from './components/img';
 import Link from 'next/link';
 
@@ -6,6 +7,10 @@ import { fetchPublicGalleries, type GalleryListItem } from '@repo/core';
 import { getServerEnv } from './lib/env';
 import { HeroSection } from './components/hero-section';
 import { Frame } from './components/frame';
+
+export const metadata: Metadata = {
+  alternates: { canonical: '/' }
+};
 
 export default async function HomePage() {
   const { ADMIN_API_BASE_URL } = getServerEnv();

--- a/apps/evrydayarchive-web/app/portfolio/[slug]/page.tsx
+++ b/apps/evrydayarchive-web/app/portfolio/[slug]/page.tsx
@@ -38,10 +38,11 @@ export const generateMetadata = async ({
     return {
       title,
       description,
+      alternates: { canonical: `/portfolio/${params.slug}` },
       openGraph: {
         title,
         description,
-        url: `https://evrydayarchive.co/portfolio/${params.slug}`,
+        url: `https://www.evrydayarchive.co/portfolio/${params.slug}`,
         type: 'website'
       },
       twitter: {

--- a/apps/evrydayarchive-web/app/portfolio/page.tsx
+++ b/apps/evrydayarchive-web/app/portfolio/page.tsx
@@ -10,7 +10,7 @@ import { Frame } from '../components/frame';
 export const metadata: Metadata = {
   title: 'Portfolio | Evryday Archive Co',
   description:
-    'Browse photography galleries by Reed McIlwain — lifestyle, family, and everyday moments documented in Kamloops and Vancouver Island.',
+    'Browse photography galleries by Reed McIlwain — lifestyle, family, and everyday moments documented across British Columbia.',
   alternates: { canonical: '/portfolio' }
 };
 

--- a/apps/evrydayarchive-web/app/portfolio/page.tsx
+++ b/apps/evrydayarchive-web/app/portfolio/page.tsx
@@ -10,7 +10,8 @@ import { Frame } from '../components/frame';
 export const metadata: Metadata = {
   title: 'Portfolio | Evryday Archive Co',
   description:
-    'Browse photography galleries by Reed McIlwain — lifestyle, family, and everyday moments documented in Kamloops and Vancouver Island.'
+    'Browse photography galleries by Reed McIlwain — lifestyle, family, and everyday moments documented in Kamloops and Vancouver Island.',
+  alternates: { canonical: '/portfolio' }
 };
 
 export const dynamic = 'force-dynamic';

--- a/apps/evrydayarchive-web/app/process/page.tsx
+++ b/apps/evrydayarchive-web/app/process/page.tsx
@@ -38,7 +38,8 @@ const STEPS = [
 export const metadata: Metadata = {
   title: 'How It Works | Evryday Archive Co',
   description:
-    'From first inquiry to final gallery — here is how Reed McIlwain documents your everyday life from start to finish.'
+    'From first inquiry to final gallery — here is how Reed McIlwain documents your everyday life from start to finish.',
+  alternates: { canonical: '/process' }
 };
 
 const ProcessPage = () => {

--- a/apps/evrydayarchive-web/app/robots.ts
+++ b/apps/evrydayarchive-web/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: '*',
       allow: '/'
     },
-    host: 'https://evrydayarchive.co',
-    sitemap: 'https://evrydayarchive.co/sitemap.xml'
+    host: 'https://www.evrydayarchive.co',
+    sitemap: 'https://www.evrydayarchive.co/sitemap.xml'
   };
 }

--- a/apps/evrydayarchive-web/app/sitemap.ts
+++ b/apps/evrydayarchive-web/app/sitemap.ts
@@ -4,7 +4,7 @@ import { fetchPublicGalleries } from '@repo/core';
 
 import { getServerEnv } from './lib/env';
 
-const BASE_URL = 'https://evrydayarchive.co';
+const BASE_URL = 'https://www.evrydayarchive.co';
 
 const staticRoutes: MetadataRoute.Sitemap = [
   { url: BASE_URL, priority: 1.0, changeFrequency: 'weekly' },

--- a/apps/evrydayarchive-web/public/llms.txt
+++ b/apps/evrydayarchive-web/public/llms.txt
@@ -1,0 +1,35 @@
+# Evryday Archive Co
+
+> Evryday Archive Co (also known as Everyday Archive Co) is a photography business run by Reed McIlwain, based in Kamloops, BC and serving Vancouver Island, BC. Reed documents ordinary life as something worth keeping — lifestyle, family, couples, and everyday moments. Sessions are designed to be low-pressure, accessible, and transparently priced with no hidden fees.
+
+## About
+
+Photographer: Reed McIlwain
+Business name: Evryday Archive Co
+Alternate name: Everyday Archive Co
+Location: Kamloops, British Columbia, Canada
+Also serves: Vancouver Island, BC (including Victoria); Vancouver, BC
+Style: Candid, documentary, lifestyle — natural light, real moments
+Pricing philosophy: Transparent and adjustable. No surprise fees. Packages are publicly listed.
+
+## Pages
+
+[Home](https://www.evrydayarchive.co): Overview of the business, featured galleries, brand philosophy, testimonials, pricing philosophy, and location.
+
+[Portfolio](https://www.evrydayarchive.co/portfolio): Gallery wall of published photography galleries by Reed McIlwain. Lifestyle, family, and everyday moments documented in Kamloops and Vancouver Island.
+
+[Packages](https://www.evrydayarchive.co/packages): Publicly listed photography session packages with transparent pricing. Includes add-on modifiers. No hidden fees.
+
+[How It Works](https://www.evrydayarchive.co/process): Five-step overview of the process from first inquiry to final gallery delivery.
+
+[Get Started / Inquire](https://www.evrydayarchive.co/inquire): Guided questionnaire to help match clients with the right session package. Covers occasion, group size, location, budget, and style preferences.
+
+[Build Your Package](https://www.evrydayarchive.co/package-builder): Step-by-step package customisation tool for clients who want to mix and match add-ons.
+
+[Book a Session](https://www.evrydayarchive.co/book): Formal session request form. Collects name, contact details, preferred date, and package selection. Date is non-binding pending confirmation.
+
+[About](https://www.evrydayarchive.co/about): Background on Reed McIlwain — the photographer, their approach, and the philosophy behind Evryday Archive Co.
+
+[FAQ](https://www.evrydayarchive.co/faq): Answers to common questions about booking, pricing, turnaround time, what to wear, and what to expect from a session.
+
+[Contact](https://www.evrydayarchive.co/contact): General contact form for questions and enquiries.

--- a/apps/evrydayarchive-web/public/llms.txt
+++ b/apps/evrydayarchive-web/public/llms.txt
@@ -1,6 +1,6 @@
 # Evryday Archive Co
 
-> Evryday Archive Co (also known as Everyday Archive Co) is a photography business run by Reed McIlwain, based in Kamloops, BC and serving Vancouver Island, BC. Reed documents ordinary life as something worth keeping — lifestyle, family, couples, and everyday moments. Sessions are designed to be low-pressure, accessible, and transparently priced with no hidden fees.
+> Evryday Archive Co (also known as Everyday Archive Co) is a photography business run by Reed McIlwain, a BC photographer based in Kamloops. Reed regularly shoots in Vancouver, Victoria, and across Vancouver Island. He documents ordinary life as something worth keeping — lifestyle, family, couples, and everyday moments. Sessions are designed to be low-pressure, accessible, and transparently priced with no hidden fees.
 
 ## About
 
@@ -8,7 +8,7 @@ Photographer: Reed McIlwain
 Business name: Evryday Archive Co
 Alternate name: Everyday Archive Co
 Location: Kamloops, British Columbia, Canada
-Also serves: Vancouver Island, BC (including Victoria); Vancouver, BC
+Regularly shoots in: Vancouver, Victoria, Vancouver Island, and across British Columbia
 Style: Candid, documentary, lifestyle — natural light, real moments
 Pricing philosophy: Transparent and adjustable. No surprise fees. Packages are publicly listed.
 
@@ -16,7 +16,7 @@ Pricing philosophy: Transparent and adjustable. No surprise fees. Packages are p
 
 [Home](https://www.evrydayarchive.co): Overview of the business, featured galleries, brand philosophy, testimonials, pricing philosophy, and location.
 
-[Portfolio](https://www.evrydayarchive.co/portfolio): Gallery wall of published photography galleries by Reed McIlwain. Lifestyle, family, and everyday moments documented in Kamloops and Vancouver Island.
+[Portfolio](https://www.evrydayarchive.co/portfolio): Gallery wall of published photography galleries by Reed McIlwain. Lifestyle, family, and everyday moments documented across British Columbia.
 
 [Packages](https://www.evrydayarchive.co/packages): Publicly listed photography session packages with transparent pricing. Includes add-on modifiers. No hidden fees.
 


### PR DESCRIPTION
## Summary

- **JSON-LD structured data** — updates `@type` to `LocalBusiness`, adds `alternateName: "Everyday Archive Co"` (the key signal for Google to associate both spellings), adds `employee` field, updates `url` to `www`, and narrows `areaServed` to Kamloops, Vancouver Island, Victoria, and Vancouver
- **Per-page OG and Twitter tags** — removes hardcoded title/description/url from the root layout's `openGraph` and `twitter` blocks; Next.js now derives these from each page's own `title` and `description`, and computes `og:url` from `metadataBase` + current route
- **Canonical URLs** — adds `<link rel="canonical">` to every public page pointing to the `www` version; updates `metadataBase` to `https://www.evrydayarchive.co` so all relative paths resolve correctly; adds a `metadata` export to the homepage which previously had none
- **Sitemap and robots.txt** — updates all URLs to `www` to match the canonical base

## Why this matters

The site resolves on both `evrydayarchive.co` and `www.evrydayarchive.co`. Without canonicals, Google was seeing every page as duplicated across two origins and splitting ranking signals between them. This PR consolidates everything under `www` consistently across the sitemap, robots, OG tags, and canonical tags.

The `alternateName` field in JSON-LD is specifically the recommended way to tell Google the business also goes by "Everyday Archive Co" — relevant to the Search Console issues you were seeing.

## Notes

- `lastModified` was considered for the sitemap but `GalleryListItem` doesn't expose `updatedAt` — using fake dates would be counterproductive; tracked in #86 notes
- `/coming-soon` page is intentionally excluded from canonical treatment
- `/portfolio/[slug]` OG image is still the site default — tracked in #86

## Test plan

- [x] Verify `<link rel="canonical">` appears in page source for several routes, all pointing to `www`
- [x] Verify `og:title`, `og:description`, and `og:url` are page-specific (not homepage values) when inspecting e.g. `/faq` or `/packages`
- [ ] Paste a URL into the [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) and confirm correct OG tags
- [ ] Check `/sitemap.xml` — all URLs should be `www`
- [ ] Check `/robots.txt` — host and sitemap pointer should be `www`
- [ ] Submit updated sitemap to Google Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)