### PR TITLE
feat(spring-sale): spring sale landing page

### DIFF
--- a/apps/evrydayarchive-web/app/book/booking-form.tsx
+++ b/apps/evrydayarchive-web/app/book/booking-form.tsx
@@ -166,9 +166,9 @@ export const BookingForm = ({
 
   const today = new Date().toISOString().split('T')[0] as string;
 
-  // Spring Sale: active whenever the sale is running and a May date is selected.
+  // Spring Sale: active whenever the sale is running and a qualifying date is selected.
   // If the user came from the builder with sale=1 and hasn't picked a date yet, treat as pending
-  // (discount shown) — it clears as soon as they pick a non-May date.
+  // (discount shown) — it clears as soon as they pick a date outside the sale window.
   const saleAnnouncementActive = isSaleAnnouncementActive();
   const discountActive =
     saleAnnouncementActive && ((springSale && !preferredDate) || isSaleDate(preferredDate));
@@ -344,7 +344,7 @@ export const BookingForm = ({
                   )}
                   {saleAnnouncementActive && preferredDate && !discountActive && (
                     <p className="mb-2 text-xs text-ink-faint">
-                      Spring Sale applies to May sessions only.
+                      Spring Sale applies to sessions before June 4th.
                     </p>
                   )}
                   <div className="flex items-baseline justify-between">
@@ -444,9 +444,9 @@ export const BookingForm = ({
                   placeholder="Choose a date"
                   hasError={!!fieldErrors.date}
                   aria-describedby={fieldErrors.date ? 'date-error' : undefined}
-                  saleMonth={
+                  saleDateRange={
                     saleAnnouncementActive
-                      ? { year: SALE.discountYear, month: SALE.discountMonth }
+                      ? { start: SALE.discountStartDate, end: SALE.discountEndDate }
                       : undefined
                   }
                 />
@@ -693,7 +693,9 @@ const SummaryPanel = ({
             </div>
           )}
           {isSaleAnnouncementActive() && hasDate && !discountActive && (
-            <p className="text-xs text-ink-faint">Spring Sale applies to May sessions only.</p>
+            <p className="text-xs text-ink-faint">
+              Spring Sale applies to sessions before June 4th.
+            </p>
           )}
           <div className="flex items-baseline justify-between">
             <span className="text-xs text-ink-faint">Estimated total</span>

--- a/apps/evrydayarchive-web/app/book/date-picker.tsx
+++ b/apps/evrydayarchive-web/app/book/date-picker.tsx
@@ -34,8 +34,8 @@ type Props = {
   placeholder?: string;
   hasError?: boolean;
   'aria-describedby'?: string;
-  /** When set, all days in this month are highlighted with a sale tint. */
-  saleMonth?: { year: number; month: number }; // month is 0-indexed
+  /** When set, days within this range (inclusive, YYYY-MM-DD) are highlighted with a sale tint. */
+  saleDateRange?: { start: string; end: string };
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -61,7 +61,7 @@ export const DatePicker = ({
   placeholder = 'Select a date',
   hasError = false,
   'aria-describedby': ariaDescribedby,
-  saleMonth
+  saleDateRange
 }: Props) => {
   const today = new Date();
 
@@ -141,8 +141,17 @@ export const DatePicker = ({
   const isToday = (day: number) =>
     today.getFullYear() === viewYear && today.getMonth() === viewMonth && today.getDate() === day;
 
-  // True when the currently-viewed month is the sale month (all days get an orange tint)
-  const isSaleMonth = !!saleMonth && viewYear === saleMonth.year && viewMonth === saleMonth.month;
+  // True when a specific day in the current view falls within the sale date range
+  const isSaleDay = (day: number) => {
+    if (!saleDateRange) return false;
+    const ymd = toYMD(viewYear, viewMonth, day);
+    return ymd >= saleDateRange.start && ymd <= saleDateRange.end;
+  };
+  // True when any day in the current view month is within the sale range (drives legend)
+  const hasAnySaleDay =
+    !!saleDateRange &&
+    toYMD(viewYear, viewMonth, 1) <= saleDateRange.end &&
+    toYMD(viewYear, viewMonth, daysInMonth) >= saleDateRange.start;
 
   // ── Schedule panel ───────────────────────────────────────────────────────
 
@@ -347,9 +356,9 @@ export const DatePicker = ({
                               ? 'cursor-not-allowed text-ink-faint opacity-30'
                               : unavailable
                                 ? 'cursor-not-allowed bg-red-100 text-red-500 dark:bg-red-950/40 dark:text-red-500'
-                                : isSaleMonth && todayCell
+                                : isSaleDay(day) && todayCell
                                   ? 'font-medium bg-accent/10 text-accent ring-1 ring-inset ring-accent/30 hover:bg-accent/20'
-                                  : isSaleMonth
+                                  : isSaleDay(day)
                                     ? 'bg-accent/10 text-accent hover:bg-accent/20'
                                     : todayCell
                                       ? 'font-medium text-ink ring-1 ring-inset ring-border hover:bg-sun'
@@ -371,7 +380,7 @@ export const DatePicker = ({
                   </span>
                   Unavailable
                 </span>
-                {isSaleMonth && (
+                {hasAnySaleDay && (
                   <span className="flex items-center gap-1.5 text-[10px] text-ink-faint">
                     <span className="inline-flex h-4 w-4 items-center justify-center rounded bg-accent/10 text-[9px] text-accent">
                       ✦

--- a/apps/evrydayarchive-web/app/book/date-picker.tsx
+++ b/apps/evrydayarchive-web/app/book/date-picker.tsx
@@ -6,7 +6,7 @@ import type { LocationWindow } from '@repo/core';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-const DAY_LABELS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+const DAY_LABELS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
 const MONTH_NAMES = [
   'January',
   'February',
@@ -118,8 +118,8 @@ export const DatePicker = ({
 
   const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
 
-  // Map JS Sunday=0 → Monday=0 so the grid starts on Monday
-  const firstDayDow = (new Date(viewYear, viewMonth, 1).getDay() + 6) % 7;
+  // JS getDay() returns 0=Sunday … 6=Saturday — matches Sunday-first grid directly
+  const firstDayDow = new Date(viewYear, viewMonth, 1).getDay();
   const totalCells = Math.ceil((firstDayDow + daysInMonth) / 7) * 7;
   const cells = Array.from({ length: totalCells }, (_, i) => {
     const d = i - firstDayDow + 1;

--- a/apps/evrydayarchive-web/app/book/page.tsx
+++ b/apps/evrydayarchive-web/app/book/page.tsx
@@ -133,7 +133,7 @@ export default async function BookPage({ searchParams }: Props) {
       : undefined;
 
   // Spring Sale: opt-in via the package builder (sale=1 param), or auto-enabled during
-  // April and May. Date validation (must be a May date) happens client-side in BookingForm.
+  // April–June 4th. Date validation (sessions must be before June 4th) happens client-side in BookingForm.
   const springSale = (sale === '1' || isSaleAutoOptIn()) && isSaleAnnouncementActive();
 
   const backHref =

--- a/apps/evrydayarchive-web/app/components/conditional-footer.tsx
+++ b/apps/evrydayarchive-web/app/components/conditional-footer.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+import { SiteFooter } from './site-footer';
+
+const NO_FOOTER_ROUTES = ['/spring-sale'];
+
+export function ConditionalFooter() {
+  const pathname = usePathname();
+  if (NO_FOOTER_ROUTES.includes(pathname)) return null;
+  return <SiteFooter />;
+}

--- a/apps/evrydayarchive-web/app/components/site-header.tsx
+++ b/apps/evrydayarchive-web/app/components/site-header.tsx
@@ -75,6 +75,8 @@ const EstStamp = () => {
 const SALE_BANNER_KEY = 'ea-sale-banner';
 
 export const SiteHeader = () => {
+  const pathname = usePathname();
+  const showSale = saleActive && pathname !== '/spring-sale';
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   // Start closed to avoid SSR/hydration mismatch; effect opens it unless user dismissed it.
   const [saleOpen, setSaleOpen] = useState(false);
@@ -82,10 +84,10 @@ export const SiteHeader = () => {
 
   // Open the banner by default on mount, unless the user has explicitly closed it.
   useEffect(() => {
-    if (saleActive && localStorage.getItem(SALE_BANNER_KEY) !== 'closed') {
+    if (showSale && localStorage.getItem(SALE_BANNER_KEY) !== 'closed') {
       setSaleOpen(true);
     }
-  }, []);
+  }, [showSale]);
 
   const handleSaleToggle = () => {
     setSaleOpen((open) => {
@@ -144,7 +146,7 @@ export const SiteHeader = () => {
                 <NavLink key={link.href} href={link.href} label={link.label} />
               ))}
 
-              {saleActive && (
+              {showSale && (
                 <button
                   type="button"
                   onClick={handleSaleToggle}
@@ -180,7 +182,7 @@ export const SiteHeader = () => {
         </div>
 
         {/* Sale panel — slides open below the nav bar */}
-        {saleActive && (
+        {showSale && (
           <div
             className={cn(
               'overflow-hidden transition-[max-height] ease-in-out',
@@ -271,7 +273,7 @@ export const SiteHeader = () => {
       </header>
 
       {/* ── Mobile: sale bar (persistent, sits above bottom nav) ─────────── */}
-      {saleActive && (
+      {showSale && (
         <div className="fixed bottom-16 left-0 right-0 z-40 md:hidden">
           {/* Expanded detail panel — bg-canvas, reveals upward from the thin label bar */}
           <div
@@ -314,7 +316,7 @@ export const SiteHeader = () => {
         isOpen={mobileMenuOpen}
         onClose={() => setMobileMenuOpen(false)}
         links={NAV}
-        bottomOffset={saleActive ? 'bottom-[92px]' : 'bottom-16'}
+        bottomOffset={showSale ? 'bottom-[92px]' : 'bottom-16'}
       />
     </>
   );

--- a/apps/evrydayarchive-web/app/components/site-header.tsx
+++ b/apps/evrydayarchive-web/app/components/site-header.tsx
@@ -196,7 +196,7 @@ export const SiteHeader = () => {
                   <span className="inline-flex items-center whitespace-nowrap rounded-sm border border-accent/40 px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-accent">
                     {SALE.name}
                   </span>
-                  Any sessions booked for May receive a 10% discount.
+                  Any sessions booked before June 4th receive a 10% discount.
                 </p>
                 <button
                   type="button"
@@ -284,7 +284,7 @@ export const SiteHeader = () => {
           >
             <div className="border-b border-border bg-sun px-4 pb-3 pt-3 text-center">
               <p className="text-sm leading-relaxed text-ink-muted">
-                Any sessions booked for May receive a 10% discount.
+                Any sessions booked before June 4th receive a 10% discount.
               </p>
             </div>
           </div>

--- a/apps/evrydayarchive-web/app/layout.tsx
+++ b/apps/evrydayarchive-web/app/layout.tsx
@@ -7,7 +7,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 
 import { ThemeProvider } from './providers/theme-provider';
 import { SiteHeader } from './components/site-header';
-import { SiteFooter } from './components/site-footer';
+import { ConditionalFooter } from './components/conditional-footer';
 import { NavigationFeedback } from './components/navigation-feedback';
 import { PageFade } from './components/page-fade';
 import { MetaPixel } from './components/meta-pixel';
@@ -150,7 +150,7 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
           <div className={saleActive ? 'pb-[92px] md:pb-0' : 'pb-16 md:pb-0'}>
             <PageFade>{children}</PageFade>
           </div>
-          {!isComingSoon && <SiteFooter />}
+          {!isComingSoon && <ConditionalFooter />}
         </ThemeProvider>
         <Analytics />
         <SpeedInsights />

--- a/apps/evrydayarchive-web/app/lib/sale.ts
+++ b/apps/evrydayarchive-web/app/lib/sale.ts
@@ -1,8 +1,8 @@
 /**
- * Spring Sale — May 2026 promotion.
+ * Spring Sale — extended through June 4th, 2026.
  *
- * Any session booked for May 2026 receives 10% off.
- * The announcement bar is visible from mid-April through end of May.
+ * Any session booked for May–June 4th 2026 receives 10% off.
+ * The announcement bar is visible from mid-April through June 4th.
  *
  * Remove or update this file when the sale ends.
  */
@@ -11,43 +11,38 @@ export const SALE = {
   name: 'Spring Sale',
   discountRate: 0.1,
   discountLabel: '10% off',
-  /** Month (0-indexed) in which submitted bookings get the discount. May = 4. */
-  discountMonth: 4,
-  discountYear: 2026
+  /** First session date (inclusive) that qualifies for the discount. YYYY-MM-DD. */
+  discountStartDate: '2026-05-01',
+  /** Last session date (inclusive) that qualifies for the discount. YYYY-MM-DD. */
+  discountEndDate: '2026-06-04'
 } as const;
 
 /**
  * True while the announcement bar should be visible.
- * Runs from now through end of May 2026.
+ * Runs from now through June 4th, 2026.
  */
 export function isSaleAnnouncementActive(): boolean {
   const now = new Date();
   const year = now.getFullYear();
-  const month = now.getMonth(); // 0-indexed
   if (year < 2026) return true; // before 2026 — show during development
   if (year > 2026) return false;
-  return month <= SALE.discountMonth; // Jan–May 2026
+  // End of day on June 4th 2026
+  return now <= new Date('2026-06-04T23:59:59');
 }
 
 /**
- * True during April and May 2026 — the window when the Spring Sale toggle should be
+ * True while the sale is active — the window when the Spring Sale toggle should be
  * pre-selected for users who land on the builder or booking page without having opted in.
  */
 export function isSaleAutoOptIn(): boolean {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = now.getMonth(); // 0-indexed
-  if (year < 2026) return true; // before 2026 — dev convenience
-  if (year > 2026) return false;
-  return month === 3 || month === SALE.discountMonth; // April (3) or May (4)
+  return isSaleAnnouncementActive();
 }
 
 /**
- * True when a booking submitted right now qualifies for the discount (May 2026 only).
+ * True when a booking submitted right now qualifies for the discount (through June 4th 2026).
  */
 export function isSaleDiscountActive(): boolean {
-  const now = new Date();
-  return now.getFullYear() === SALE.discountYear && now.getMonth() === SALE.discountMonth;
+  return isSaleAnnouncementActive();
 }
 
 /** Apply the sale discount to a price in cents, rounding to nearest cent. */
@@ -56,14 +51,11 @@ export function applyDiscount(cents: number): number {
 }
 
 /**
- * Returns true if a YYYY-MM-DD date string falls within the sale's discount month.
- * Used client-side on the booking page to validate the selected shoot date.
+ * Returns true if a YYYY-MM-DD date string falls within the sale's discount window
+ * (May 1 – June 4, 2026 inclusive). Used client-side on the booking page to validate
+ * the selected shoot date.
  */
 export function isSaleDate(dateStr: string): boolean {
   if (!dateStr) return false;
-  const parts = dateStr.split('-');
-  if (parts.length < 2) return false;
-  const year = parseInt(parts[0]!, 10);
-  const month = parseInt(parts[1]!, 10); // 1-indexed in YYYY-MM-DD
-  return year === SALE.discountYear && month === SALE.discountMonth + 1;
+  return dateStr >= SALE.discountStartDate && dateStr <= SALE.discountEndDate;
 }

--- a/apps/evrydayarchive-web/app/package-builder/builder-card.tsx
+++ b/apps/evrydayarchive-web/app/package-builder/builder-card.tsx
@@ -373,7 +373,7 @@ const SpringSaleRow = ({ enabled, discountCents, onToggle }: SpringSaleRowProps)
         </span>
       </div>
       <p className="text-xs leading-relaxed text-ink-faint">
-        Book for May and receive 10% off — discount confirmed at checkout.
+        Book before June 4th and receive 10% off — discount confirmed at checkout.
       </p>
     </div>
     <div className="flex flex-none flex-col items-end gap-1.5">

--- a/apps/evrydayarchive-web/app/spring-sale/page.tsx
+++ b/apps/evrydayarchive-web/app/spring-sale/page.tsx
@@ -117,15 +117,15 @@ export default function SpringSalePage() {
             {PACKAGES.map((pkg) => (
               <div
                 key={pkg.slug}
-                className="flex flex-col justify-between rounded-card border border-border bg-surface p-5"
+                className="flex flex-col justify-between rounded-card border border-border bg-surface p-5 min-[375px]:flex-row min-[375px]:items-center sm:flex-col sm:justify-between"
               >
-                <div className="mb-6">
+                <div className="mb-6 min-[375px]:mb-0 sm:mb-6">
                   <p className="mb-1 text-base font-semibold text-ink">{pkg.label}</p>
                   <p className="text-sm leading-relaxed text-ink-muted">{pkg.descriptor}</p>
                 </div>
                 <Link
                   href={`/package-builder?package=${pkg.slug}`}
-                  className="block rounded-card border border-accent px-4 py-3 text-center text-sm font-medium text-accent transition-colors duration-fast hover:bg-accent hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent lg:border-transparent lg:bg-accent lg:text-white lg:hover:opacity-90"
+                  className="block shrink-0 rounded-card bg-accent px-4 py-3 text-center text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent min-[375px]:inline-block sm:block"
                 >
                   Start here
                 </Link>

--- a/apps/evrydayarchive-web/app/spring-sale/page.tsx
+++ b/apps/evrydayarchive-web/app/spring-sale/page.tsx
@@ -53,14 +53,15 @@ export default function SpringSalePage() {
        * lg+: two-column split — text left, image right.
        *   - min-h-0, image column sets height via lg:min-h-[640px].
        */}
-      <section className="relative overflow-hidden bg-canvas lg:flex">
+      <section className="relative overflow-hidden bg-black lg:bg-canvas lg:flex">
         <div className="relative z-10 flex min-h-[100svh] items-end md:min-h-[calc(100svh-4rem)] lg:min-h-0 lg:w-1/2 lg:shrink-0 lg:items-center">
           <div className="px-6 pb-28 sm:px-10 md:pb-16 lg:px-16 lg:py-24">
             <h1 className="mb-3 max-w-lg text-3xl font-semibold leading-tight text-white sm:text-4xl lg:max-w-none lg:text-5xl lg:text-ink">
-              10% off any session. Book before May 31st.
+              10% off any session. <br />
+              Book before May 31st.
             </h1>
             <p className="text-base text-white/75 sm:text-lg lg:text-ink-muted">
-              Whatever you&apos;re documenting — yourself, the people around you, your work, your events.
+              TODO COME UP WITH SOMETHING
             </p>
           </div>
         </div>
@@ -70,7 +71,7 @@ export default function SpringSalePage() {
             src="https://res.cloudinary.com/dlib7syhc/image/upload/v1774848987/galleries/jessica-and-her-toyota/mlb50mmgpcp9zonfebn1.jpg"
             alt="Evryday Archive Co — spring sale"
             fill
-            className="object-cover object-center"
+            className="object-cover object-[30%_50%] lg:object-center"
             priority
             sizes="(min-width: 1024px) 50vw, 100vw"
           />
@@ -83,7 +84,7 @@ export default function SpringSalePage() {
         <div className="mx-auto max-w-2xl">
           <p className="text-lg leading-relaxed text-ink-muted sm:text-xl">
             <span className="font-medium text-ink">10% off any package</span>, for Kamloops sessions
-            booked before May 31st. No code needed — pick the package that fits and the discount is
+            booked before May 31st. No code needed. Pick the package that fits and the discount is
             reflected in the final price.
           </p>
         </div>

--- a/apps/evrydayarchive-web/app/spring-sale/page.tsx
+++ b/apps/evrydayarchive-web/app/spring-sale/page.tsx
@@ -1,0 +1,138 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Spring Sale — 10% Off Any Session | Evryday Archive Co',
+  description:
+    '10% off any photography package for Kamloops sessions booked before May 31st. No code needed — pick your package and get started.',
+  alternates: { canonical: '/spring-sale' }
+};
+
+const PACKAGES = [
+  {
+    label: 'For me',
+    descriptor: 'Solo sessions, one on one.',
+    slug: 'evryday'
+  },
+  {
+    label: 'For me + some people',
+    descriptor: 'Couples, friends, or the whole crew.',
+    slug: 'together'
+  },
+  {
+    label: 'For my work or business',
+    descriptor: 'Commercial, product, or professional content.',
+    slug: 'in-practice'
+  },
+  {
+    label: 'For my event',
+    descriptor: 'Gatherings, performances, community moments.',
+    slug: 'as-it-unfolds'
+  }
+];
+
+export default function SpringSalePage() {
+  return (
+    <main>
+      {/* ── Hero ──────────────────────────────────────────────────────────────── */}
+      <section className="relative h-svh min-h-[560px] w-full overflow-hidden bg-sun">
+        {/*
+         * TODO: Replace this comment block with the hero image:
+         * import Image from '../components/img';
+         * <Image
+         *   src="/images/spring-sale/hero.jpg"
+         *   alt="Evryday Archive Co — spring sale"
+         *   fill
+         *   className="object-cover object-center"
+         *   priority
+         *   sizes="100vw"
+         * />
+         */}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/20 to-transparent" />
+        <div className="absolute bottom-0 left-0 px-6 pb-12 sm:px-10 sm:pb-16 lg:px-16 lg:pb-20">
+          <h1 className="mb-3 max-w-lg text-3xl font-semibold leading-tight text-white sm:text-4xl lg:text-5xl">
+            10% off any session. Book before May 31st.
+          </h1>
+          <p className="text-base text-white/75 sm:text-lg">
+            Kamloops photography that fits your life — and your budget.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Offer Block ───────────────────────────────────────────────────────── */}
+      <section className="px-4 py-14 sm:px-6 sm:py-16 lg:px-8">
+        <div className="mx-auto max-w-2xl">
+          <p className="text-lg leading-relaxed text-ink-muted sm:text-xl">
+            <span className="font-medium text-ink">10% off any package</span>, for Kamloops sessions
+            booked before May 31st. No code needed — pick the package that fits and the discount is
+            reflected in the final price.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Image Gallery ─────────────────────────────────────────────────────── */}
+      {/*
+       * TODO: Replace each placeholder div with:
+       * <div className="relative aspect-[x/y] overflow-hidden rounded-sm">
+       *   <Image src="/images/spring-sale/gallery-N.jpg" alt="..." fill className="object-cover" sizes="..." />
+       * </div>
+       *
+       * Suggested sizes attributes:
+       *   - Tall portrait (col-span-1):  sizes="(min-width: 640px) 50vw, 100vw"
+       *   - Wide landscape (col-span-2): sizes="100vw"
+       *
+       * Drop images into: public/images/spring-sale/
+       */}
+      <section className="px-4 pb-16 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-5xl">
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-3">
+            <div className="relative aspect-[3/4] overflow-hidden rounded-sm bg-sun" />
+            <div className="relative aspect-[3/4] overflow-hidden rounded-sm bg-mat-linen" />
+            <div className="relative aspect-[3/2] overflow-hidden rounded-sm bg-sun sm:col-span-2" />
+            <div className="relative aspect-[3/4] overflow-hidden rounded-sm bg-mat-linen" />
+            <div className="relative aspect-[3/4] overflow-hidden rounded-sm bg-sun" />
+          </div>
+        </div>
+      </section>
+
+      {/* ── Package Selector ──────────────────────────────────────────────────── */}
+      <section className="px-4 py-16 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-4xl">
+          <h2 className="mb-8 text-2xl font-semibold text-ink sm:mb-10 sm:text-3xl">
+            Find the right fit
+          </h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {PACKAGES.map((pkg) => (
+              <div
+                key={pkg.slug}
+                className="flex flex-col justify-between rounded-card border border-border bg-surface p-5"
+              >
+                <div className="mb-6">
+                  <p className="mb-1 text-base font-semibold text-ink">{pkg.label}</p>
+                  <p className="text-sm leading-relaxed text-ink-muted">{pkg.descriptor}</p>
+                </div>
+                <Link
+                  href={`/package-builder?package=${pkg.slug}`}
+                  className="block rounded-card bg-accent px-4 py-3 text-center text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                >
+                  Build this package
+                </Link>
+              </div>
+            ))}
+          </div>
+
+          {/* Portfolio nudge */}
+          <p className="mt-10 text-sm text-ink-muted">
+            Not sure yet?{' '}
+            <Link
+              href="/portfolio"
+              className="text-ink underline underline-offset-2 transition-opacity duration-fast hover:opacity-60"
+            >
+              Take a look at the work first.
+            </Link>
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/evrydayarchive-web/app/spring-sale/page.tsx
+++ b/apps/evrydayarchive-web/app/spring-sale/page.tsx
@@ -5,7 +5,7 @@ import Image from '../components/img';
 export const metadata: Metadata = {
   title: 'Spring Sale — 10% Off Any Session | Evryday Archive Co',
   description:
-    '10% off any photography package for Kamloops sessions booked before May 31st. No code needed — pick your package and get started.',
+    '10% off any photography package for Kamloops sessions booked before June 4th. No code needed — pick your package and get started.',
   alternates: { canonical: '/spring-sale' }
 };
 
@@ -58,7 +58,7 @@ export default function SpringSalePage() {
           <div className="px-6 pb-28 sm:px-10 md:pb-16 lg:px-16 lg:py-24">
             <h1 className="mb-3 max-w-lg text-3xl font-semibold leading-tight text-white sm:text-4xl lg:max-w-none lg:text-5xl lg:text-ink">
               10% off any session. <br />
-              Book before May 31st.
+              Book before June 4th.
             </h1>
             <p className="text-base text-white/75 sm:text-lg lg:text-ink-muted">
               Everyday life deserves to be remembered.
@@ -85,7 +85,7 @@ export default function SpringSalePage() {
         <div className="mx-auto max-w-2xl">
           <p className="text-lg leading-relaxed text-ink-muted sm:text-xl">
             <span className="font-medium text-ink">10% off any package</span>, for Kamloops sessions
-            booked before May 31st. No code needed. Pick the package that fits and the discount is
+            booked before June 4th. No code needed. Pick the package that fits and the discount is
             reflected in the final price.
           </p>
         </div>

--- a/apps/evrydayarchive-web/app/spring-sale/page.tsx
+++ b/apps/evrydayarchive-web/app/spring-sale/page.tsx
@@ -35,27 +35,39 @@ export default function SpringSalePage() {
   return (
     <main>
       {/* ── Hero ──────────────────────────────────────────────────────────────── */}
-      <section className="relative h-svh min-h-[560px] w-full overflow-hidden bg-sun">
-        {/*
-         * TODO: Replace this comment block with the hero image:
-         * import Image from '../components/img';
-         * <Image
-         *   src="/images/spring-sale/hero.jpg"
-         *   alt="Evryday Archive Co — spring sale"
-         *   fill
-         *   className="object-cover object-center"
-         *   priority
-         *   sizes="100vw"
-         * />
-         */}
-        <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/20 to-transparent" />
-        <div className="absolute bottom-0 left-0 px-6 pb-12 sm:px-10 sm:pb-16 lg:px-16 lg:pb-20">
-          <h1 className="mb-3 max-w-lg text-3xl font-semibold leading-tight text-white sm:text-4xl lg:text-5xl">
-            10% off any session. Book before May 31st.
-          </h1>
-          <p className="text-base text-white/75 sm:text-lg">
-            Kamloops photography that fits your life — and your budget.
-          </p>
+      {/*
+       * Mobile: full-bleed image with text overlaid at bottom-left.
+       * Desktop (lg+): two-column split — text left, image right.
+       */}
+      <section className="relative overflow-hidden bg-canvas lg:flex">
+        {/* Text: overlaid on image on mobile; left column on desktop */}
+        <div className="relative z-10 flex min-h-[100svh] items-end lg:min-h-0 lg:w-1/2 lg:shrink-0 lg:items-center">
+          <div className="px-6 pb-12 sm:px-10 sm:pb-16 lg:px-16 lg:py-24">
+            <h1 className="mb-3 max-w-lg text-3xl font-semibold leading-tight text-white sm:text-4xl lg:max-w-none lg:text-5xl lg:text-ink">
+              10% off any session. Book before May 31st.
+            </h1>
+            <p className="text-base text-white/75 sm:text-lg lg:text-ink-muted">
+              Kamloops photography that fits your life — and your budget.
+            </p>
+          </div>
+        </div>
+
+        {/* Image: full-bleed background on mobile; right column on desktop */}
+        <div className="absolute inset-0 bg-sun lg:relative lg:inset-auto lg:flex-1 lg:min-h-[640px]">
+          {/*
+           * TODO: Replace with the hero image:
+           * import Image from '../components/img';
+           * <Image
+           *   src="https://res.cloudinary.com/YOUR_CLOUD/image/upload/..."
+           *   alt="Evryday Archive Co — spring sale"
+           *   fill
+           *   className="object-cover object-center"
+           *   priority
+           *   sizes="(min-width: 1024px) 50vw, 100vw"
+           * />
+           */}
+          {/* Gradient for mobile text legibility — not needed on desktop */}
+          <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/20 to-transparent lg:hidden" />
         </div>
       </section>
 

--- a/apps/evrydayarchive-web/app/spring-sale/page.tsx
+++ b/apps/evrydayarchive-web/app/spring-sale/page.tsx
@@ -12,7 +12,7 @@ const PACKAGES = [
   {
     label: 'For me',
     descriptor: 'Solo sessions, one on one.',
-    slug: 'evryday'
+    slug: 'evryday-package'
   },
   {
     label: 'For me + some people',
@@ -125,9 +125,9 @@ export default function SpringSalePage() {
                 </div>
                 <Link
                   href={`/package-builder?package=${pkg.slug}`}
-                  className="block rounded-card bg-accent px-4 py-3 text-center text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                  className="block rounded-card border border-accent px-4 py-3 text-center text-sm font-medium text-accent transition-colors duration-fast hover:bg-accent hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent lg:border-transparent lg:bg-accent lg:text-white lg:hover:opacity-90"
                 >
-                  Build this package
+                  Start here
                 </Link>
               </div>
             ))}

--- a/apps/evrydayarchive-web/app/spring-sale/page.tsx
+++ b/apps/evrydayarchive-web/app/spring-sale/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import Image from '../components/img';
 
 export const metadata: Metadata = {
   title: 'Spring Sale — 10% Off Any Session | Evryday Archive Co',
@@ -10,24 +11,32 @@ export const metadata: Metadata = {
 
 const PACKAGES = [
   {
-    label: 'For me',
+    label: 'For you',
     descriptor: 'Solo sessions, one on one.',
-    slug: 'evryday-package'
+    slug: 'evryday-package',
+    src: 'https://res.cloudinary.com/dlib7syhc/image/upload/v1774917240/galleries/urec/wj3dtqh9ewd9qgmjorr7.jpg',
+    alt: 'Ruben with the UVic Renewable Energy Club, posing for a headshot'
   },
   {
-    label: 'For me + some people',
+    label: 'For you + your people',
     descriptor: 'Couples, friends, or the whole crew.',
-    slug: 'together'
+    slug: 'together',
+    src: 'https://res.cloudinary.com/dlib7syhc/image/upload/v1774917667/galleries/nicole-and-nikki/zbzcvrkz66icb1hnyoxl.jpg',
+    alt: 'Nicole & Nikki on a bench near the Victoria Harbour'
   },
   {
-    label: 'For my work or business',
+    label: 'For your work or business',
     descriptor: 'Commercial, product, or professional content.',
-    slug: 'in-practice'
+    slug: 'in-practice',
+    src: 'https://res.cloudinary.com/dlib7syhc/image/upload/v1774051454/galleries/science-of-wine/dg3geuvdp8vqtixklf1q.jpg',
+    alt: 'Wine is poured during the Science of Wine event at the Big Little Science Centre.'
   },
   {
-    label: 'For my event',
+    label: 'For your event',
     descriptor: 'Gatherings, performances, community moments.',
-    slug: 'as-it-unfolds'
+    slug: 'as-it-unfolds',
+    src: 'https://res.cloudinary.com/dlib7syhc/image/upload/v1774919288/galleries/valleyview-alumni-game/e4jxdumk5wl0gjeifbic.jpg',
+    alt: 'A player takes a jump shot after driving to the hoop during the 2025 Valleyview Alumni Basketball Game.'
   }
 ];
 
@@ -36,37 +45,35 @@ export default function SpringSalePage() {
     <main>
       {/* ── Hero ──────────────────────────────────────────────────────────────── */}
       {/*
-       * Mobile: full-bleed image with text overlaid at bottom-left.
-       * Desktop (lg+): two-column split — text left, image right.
+       * Mobile: full-bleed image, text overlaid at bottom-left.
+       *   - No top header; fixed bottom nav (h-16) + sale bar (h-7) = 92px chrome.
+       *   - min-h-[100svh], pb-28 (112px) keeps text clear of the bottom chrome.
+       * md–lg: sticky top header (h-16); no bottom chrome.
+       *   - min-h-[calc(100svh-4rem)] fills exactly the viewport below the nav.
+       * lg+: two-column split — text left, image right.
+       *   - min-h-0, image column sets height via lg:min-h-[640px].
        */}
       <section className="relative overflow-hidden bg-canvas lg:flex">
-        {/* Text: overlaid on image on mobile; left column on desktop */}
-        <div className="relative z-10 flex min-h-[100svh] items-end lg:min-h-0 lg:w-1/2 lg:shrink-0 lg:items-center">
-          <div className="px-6 pb-12 sm:px-10 sm:pb-16 lg:px-16 lg:py-24">
+        <div className="relative z-10 flex min-h-[100svh] items-end md:min-h-[calc(100svh-4rem)] lg:min-h-0 lg:w-1/2 lg:shrink-0 lg:items-center">
+          <div className="px-6 pb-28 sm:px-10 md:pb-16 lg:px-16 lg:py-24">
             <h1 className="mb-3 max-w-lg text-3xl font-semibold leading-tight text-white sm:text-4xl lg:max-w-none lg:text-5xl lg:text-ink">
               10% off any session. Book before May 31st.
             </h1>
             <p className="text-base text-white/75 sm:text-lg lg:text-ink-muted">
-              Kamloops photography that fits your life — and your budget.
+              Whatever you&apos;re documenting — yourself, the people around you, your work, your events.
             </p>
           </div>
         </div>
 
-        {/* Image: full-bleed background on mobile; right column on desktop */}
-        <div className="absolute inset-0 bg-sun lg:relative lg:inset-auto lg:flex-1 lg:min-h-[640px]">
-          {/*
-           * TODO: Replace with the hero image:
-           * import Image from '../components/img';
-           * <Image
-           *   src="https://res.cloudinary.com/YOUR_CLOUD/image/upload/..."
-           *   alt="Evryday Archive Co — spring sale"
-           *   fill
-           *   className="object-cover object-center"
-           *   priority
-           *   sizes="(min-width: 1024px) 50vw, 100vw"
-           * />
-           */}
-          {/* Gradient for mobile text legibility — not needed on desktop */}
+        <div className="absolute inset-0 lg:relative lg:inset-auto lg:flex-1 lg:min-h-[640px]">
+          <Image
+            src="https://res.cloudinary.com/dlib7syhc/image/upload/v1774848987/galleries/jessica-and-her-toyota/mlb50mmgpcp9zonfebn1.jpg"
+            alt="Evryday Archive Co — spring sale"
+            fill
+            className="object-cover object-center"
+            priority
+            sizes="(min-width: 1024px) 50vw, 100vw"
+          />
           <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/20 to-transparent lg:hidden" />
         </div>
       </section>
@@ -82,34 +89,9 @@ export default function SpringSalePage() {
         </div>
       </section>
 
-      {/* ── Image Gallery ─────────────────────────────────────────────────────── */}
-      {/*
-       * TODO: Replace each placeholder div with:
-       * <div className="relative aspect-[x/y] overflow-hidden rounded-sm">
-       *   <Image src="/images/spring-sale/gallery-N.jpg" alt="..." fill className="object-cover" sizes="..." />
-       * </div>
-       *
-       * Suggested sizes attributes:
-       *   - Tall portrait (col-span-1):  sizes="(min-width: 640px) 50vw, 100vw"
-       *   - Wide landscape (col-span-2): sizes="100vw"
-       *
-       * Drop images into: public/images/spring-sale/
-       */}
+      {/* ── Package Cards ─────────────────────────────────────────────────────── */}
       <section className="px-4 pb-16 sm:px-6 lg:px-8">
-        <div className="mx-auto max-w-5xl">
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-3">
-            <div className="relative aspect-[3/4] overflow-hidden rounded-sm bg-sun" />
-            <div className="relative aspect-[3/4] overflow-hidden rounded-sm bg-mat-linen" />
-            <div className="relative aspect-[3/2] overflow-hidden rounded-sm bg-sun sm:col-span-2" />
-            <div className="relative aspect-[3/4] overflow-hidden rounded-sm bg-mat-linen" />
-            <div className="relative aspect-[3/4] overflow-hidden rounded-sm bg-sun" />
-          </div>
-        </div>
-      </section>
-
-      {/* ── Package Selector ──────────────────────────────────────────────────── */}
-      <section className="px-4 py-16 sm:px-6 lg:px-8">
-        <div className="mx-auto max-w-4xl">
+        <div className="mx-auto max-w-6xl">
           <h2 className="mb-8 text-2xl font-semibold text-ink sm:mb-10 sm:text-3xl">
             Find the right fit
           </h2>
@@ -117,23 +99,33 @@ export default function SpringSalePage() {
             {PACKAGES.map((pkg) => (
               <div
                 key={pkg.slug}
-                className="flex flex-col justify-between rounded-card border border-border bg-surface p-5 min-[375px]:flex-row min-[375px]:items-center sm:flex-col sm:justify-between"
+                className="flex flex-col overflow-hidden rounded-card border border-border bg-surface"
               >
-                <div className="mb-6 min-[375px]:mb-0 sm:mb-6">
-                  <p className="mb-1 text-base font-semibold text-ink">{pkg.label}</p>
-                  <p className="text-sm leading-relaxed text-ink-muted">{pkg.descriptor}</p>
+                <div className="relative aspect-[3/4] w-full overflow-hidden">
+                  <Image
+                    src={pkg.src}
+                    alt={pkg.alt}
+                    fill
+                    className="object-cover"
+                    sizes="(min-width: 1024px) 25vw, (min-width: 640px) 50vw, 100vw"
+                  />
                 </div>
-                <Link
-                  href={`/package-builder?package=${pkg.slug}`}
-                  className="block shrink-0 rounded-card bg-accent px-4 py-3 text-center text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent min-[375px]:inline-block sm:block"
-                >
-                  Start here
-                </Link>
+                <div className="flex flex-1 flex-col justify-between p-5">
+                  <div className="mb-5">
+                    <p className="mb-1 text-base font-semibold text-ink">{pkg.label}</p>
+                    <p className="text-sm leading-relaxed text-ink-muted">{pkg.descriptor}</p>
+                  </div>
+                  <Link
+                    href={`/package-builder?package=${pkg.slug}`}
+                    className="block rounded-card bg-accent px-4 py-3 text-center text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                  >
+                    Start here
+                  </Link>
+                </div>
               </div>
             ))}
           </div>
 
-          {/* Portfolio nudge */}
           <p className="mt-10 text-sm text-ink-muted">
             Not sure yet?{' '}
             <Link

--- a/apps/evrydayarchive-web/app/spring-sale/page.tsx
+++ b/apps/evrydayarchive-web/app/spring-sale/page.tsx
@@ -61,7 +61,7 @@ export default function SpringSalePage() {
               Book before May 31st.
             </h1>
             <p className="text-base text-white/75 sm:text-lg lg:text-ink-muted">
-              TODO COME UP WITH SOMETHING
+              Everyday life deserves to be remembered.
             </p>
           </div>
         </div>
@@ -73,9 +73,10 @@ export default function SpringSalePage() {
             fill
             className="object-cover object-[30%_50%] lg:object-center"
             priority
-            sizes="(min-width: 1024px) 50vw, 100vw"
+            quality={95}
+            sizes="(min-width: 1024px) 100vw, 200vw"
           />
-          <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/20 to-transparent lg:hidden" />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-black/10 to-transparent lg:hidden" />
         </div>
       </section>
 

--- a/requirements/spring-sale-landing-page-spec.md
+++ b/requirements/spring-sale-landing-page-spec.md
@@ -1,0 +1,126 @@
+# Landing Page Spec: Spring Sale
+
+**Route:** `/spring-sale`  
+**Brand:** Evryday Archive Co  
+**Purpose:** Paid ad entry point — warm handoff to package builder, not a direct converter
+
+---
+
+## Context
+
+This page is the destination for a Meta/Instagram ad campaign targeting Kamloops. The goal is to give someone who clicked an ad a more intentional entry point than the homepage — oriented around the sale offer, with a clear path into whichever package fits them. The page does not need to close anyone; it needs to orient them and get them one step closer to the right package.
+
+---
+
+## The Offer
+
+- **10% off** any package
+- **Deadline:** May 31, 2026
+- **Geography:** Kamloops only (relevant for copy tone, not enforced technically)
+- **No deposit extension on this page** — keep messaging clean; if someone asks after the deadline, handle it conversationally
+
+---
+
+## Page Structure
+
+### 1. Header / Nav
+
+- Use the existing site nav
+- No modifications needed
+
+### 2. Hero Section
+
+- Full-width, large hero image (manually selected by Reed)
+- Overlay or adjacent headline — direct, not clever
+- Suggested headline direction: what the sale is + the deadline, in plain language
+- One supporting line maximum — something that frames Evryday Archive Co's positioning (accessible, transparent, everyday moments)
+- No CTA in the hero; let the image breathe and pull the user down
+
+### 3. Offer Block
+
+- Short, scannable — 2-3 sentences max
+- Communicate: 10% off, any package, before May 31st
+- Tone: confident and warm, not urgent or pushy
+- No asterisks, no fine print
+
+### 4. Image Gallery
+
+- 3–5 images, manually curated by Reed
+- Large format — these should feel editorial, not thumbnail
+- **Desktop:** side-by-side or asymmetric grid layout
+- **Mobile:** full-width stacked, one per row, no cropping — images are the product, treat them accordingly
+- No captions needed
+
+### 5. Package Selector
+
+- Heading that invites self-selection — something like "Find the right fit"
+- Four cards or tiles, one per package:
+  | Label | Target |
+  |---|---|
+  | For me | Solo/individual package builder |
+  | For me + some people | Small group package builder |
+  | For my work or business | Commercial package builder |
+  | For my event | Event package builder |
+- Each card has a single CTA button that links directly into the package builder for that package
+- Keep the cards visual but not complex — label, one-line descriptor, button
+- **Mobile:** full-width stacked cards
+
+### 6. Portfolio Nudge
+
+- A single low-key line + text link pointing to the portfolio
+- Not a section — just a line between the package selector and the end of the page
+- Something like: "Not sure yet? Take a look at the work first." → links to `/portfolio`
+
+### 7. Footer
+
+- **Omitted on this page** — keep the user focused
+
+---
+
+## Mobile Considerations
+
+Mobile is the primary entry point (ad click → phone). Design mobile-first:
+
+- Hero image: full viewport height, portrait-friendly crop if possible
+- Text: large enough to read without zooming, minimal line count
+- Package cards: full width, generous tap targets on CTA buttons
+- Gallery: single column, full width, no horizontal scroll
+- No hover-dependent interactions
+
+---
+
+## Copy Tone
+
+Consistent with the broader Evryday Archive Co voice:
+
+- Plain language, no fluff
+- Warm but not salesy
+- Specific over vague (say "10% off before May 31st" not "limited time savings")
+- No exclamation marks
+
+---
+
+## Links Required
+
+The following links must be functional before this page goes live:
+
+- Package builder URLs for all four packages (confirm these with Reed)
+- `/portfolio` for the nudge link
+- Existing nav links (inherited from site)
+
+---
+
+## Assets to Provide
+
+- Hero image (1 image, Reed to supply)
+- Gallery images (3–5 images, Reed to supply)
+- Package builder URLs for each of the four packages
+
+---
+
+## Out of Scope
+
+- Deposit extension mechanic (handle conversationally if asked)
+- Any form or inquiry flow on this page
+- Geo-restriction or audience detection
+- Analytics events beyond what the existing pixel already captures (PageView fires automatically; no custom events required for this page unless a Lead event is added to the package builder entry — recommended but separate task)


### PR DESCRIPTION
## Summary

- Adds \`/spring-sale\` landing page for the Meta ad campaign (10% off any session, booked before June 4th)
- Two-column hero on desktop, full-bleed image with text overlay on mobile
- Four package cards linking to \`/package-builder?package=<slug>\`
- Hero image quality bumped to 95 and \`sizes\` doubled to compensate for tight portrait crop
- Mobile gradient overlay reduced (black/55 → black/35, via black/20 → black/10) so the photo retains more of its original character
- Extended sale deadline from May 31st → June 4th across all copy and logic: \`sale.ts\` now uses a \`discountStartDate\`/\`discountEndDate\` range instead of a single month; the calendar date picker highlights eligible days per-day (so June shows only June 1–4 in orange rather than the full month)

## Test plan

- [x] Visit \`/spring-sale\` on mobile — hero fills viewport, text is legible over the lightened gradient
- [x] Visit \`/spring-sale\` on desktop — two-column layout renders correctly
- [x] Confirm hero image loads at noticeably higher resolution / detail
- [ ] Tap each package card CTA and confirm it routes to the correct \`/package-builder?package=\` URL
- [x] Check light and dark mode
- [x] On the booking page, confirm May dates show the Spring Sale tint in the calendar
- [x] On the booking page, confirm June 1–4 show the tint but June 5+ do not
- [x] Confirm the site header banner reads "before June 4th" on all pages
- [x] Confirm the spring sale toggle in the package builder reads "before June 4th"

🤖 Generated with [Claude Code](https://claude.com/claude-code)