### PR TITLE
feat(process+faq): rewrite content, add accordion UI, and improve site-wide navigation

### DIFF
--- a/apps/evrydayarchive-web/app/about/page.tsx
+++ b/apps/evrydayarchive-web/app/about/page.tsx
@@ -333,6 +333,12 @@ export default function AboutPage() {
               Get in touch
             </Link>
           </div>
+          <Link
+            href="/process"
+            className="mt-4 inline-flex items-center gap-1 text-sm text-ink-muted transition-[color,transform] duration-fast hover:translate-x-1.5 hover:text-ink"
+          >
+            See how it works →
+          </Link>
         </section>
       </div>
 
@@ -517,6 +523,12 @@ export default function AboutPage() {
                 Get in touch
               </Link>
             </div>
+            <Link
+              href="/process"
+              className="mt-5 inline-flex items-center gap-1 text-sm text-ink-muted transition-[color,transform] duration-fast hover:translate-x-1.5 hover:text-ink"
+            >
+              See how it works →
+            </Link>
           </div>
         </section>
       </div>

--- a/apps/evrydayarchive-web/app/about/page.tsx
+++ b/apps/evrydayarchive-web/app/about/page.tsx
@@ -328,7 +328,7 @@ export default function AboutPage() {
           <div className="mt-6">
             <Link
               href="/inquire"
-              className="block w-full rounded bg-accent py-3 text-[13px] font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              className="block w-full rounded-card bg-accent py-3 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
             >
               Get in touch
             </Link>
@@ -518,7 +518,7 @@ export default function AboutPage() {
             <div className="mt-8">
               <Link
                 href="/inquire"
-                className="inline-block rounded bg-accent px-8 py-3 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                className="inline-block rounded-card bg-accent px-8 py-3 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
               >
                 Get in touch
               </Link>

--- a/apps/evrydayarchive-web/app/components/site-footer.tsx
+++ b/apps/evrydayarchive-web/app/components/site-footer.tsx
@@ -7,7 +7,9 @@ import { FooterEmailCapture } from './footer-email-capture';
 const NAV = [
   { href: '/portfolio', label: 'Portfolio' },
   { href: '/about', label: 'About' },
-  { href: '/packages', label: 'Packages' }
+  { href: '/packages', label: 'Packages' },
+  { href: '/process', label: 'Process' },
+  { href: '/faq', label: 'FAQ' }
 ];
 
 export const SiteFooter = () => {

--- a/apps/evrydayarchive-web/app/faq/faq-accordion.tsx
+++ b/apps/evrydayarchive-web/app/faq/faq-accordion.tsx
@@ -48,7 +48,7 @@ const FAQ_ITEMS = [
           breakdown on the{' '}
           <a
             href="/packages"
-            className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            className="font-medium text-ink underline underline-offset-2 focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
           >
             Packages
           </a>{' '}

--- a/apps/evrydayarchive-web/app/faq/faq-accordion.tsx
+++ b/apps/evrydayarchive-web/app/faq/faq-accordion.tsx
@@ -4,16 +4,177 @@ import { useState } from 'react';
 
 import { cn } from '../lib/cn';
 
-type FaqItem = {
-  question: string;
-  answer: string;
-};
+const FAQ_ITEMS = [
+  {
+    question: 'What kinds of sessions do you do?',
+    answer: (
+      <>
+        <p>
+          Photography has been a part of my life for as long as I can remember, and my artistic
+          practice has always been about doing as much as possible rather than narrowing in on one
+          thing. That carries over into Evryday Archive Co. If it&apos;s something you care about
+          capturing, I want to be involved.
+        </p>
+        <p>
+          That means portraits, couples, families, pets, events, sports, small businesses, products,
+          and even more abstract or experimental work. I&apos;m here to help document what you love,
+          and to help you flesh out ideas and visions in a collaborative way when you have something
+          specific in mind.
+        </p>
+      </>
+    )
+  },
+  {
+    question: 'How far ahead should I book?',
+    answer: (
+      <p>
+        It depends, and I&apos;m usually flexible enough to make last-minute sessions work. More
+        lead time gives us more room to work out the details, but a shorter window isn&apos;t
+        necessarily a problem.
+        <br />
+        <br />
+        If there&apos;s travel involved, it&apos;s worth checking the calendar on the booking page
+        to see where I&apos;ll be. I move between Kamloops, Vancouver, and Victoria regularly, so
+        timing can sometimes line up more easily than you&apos;d expect.
+      </p>
+    )
+  },
+  {
+    question: 'How does pricing work? How many photos will I get?',
+    answer: (
+      <>
+        <p>
+          Each package has a base image count included in the session price. You can find the full
+          breakdown on the{' '}
+          <a
+            href="/packages"
+            className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+          >
+            Packages
+          </a>{' '}
+          page.
+        </p>
+        <p>
+          After you receive your preview gallery, you can select fewer images than your package
+          includes, or add more at $7 per image. Most clients end up adding a few after seeing the
+          work. That&apos;s expected and built into how the process works.
+        </p>
+        <p>
+          <strong className="font-medium text-ink">As It Unfolds</strong> (event coverage) works
+          differently. Image delivery for events is based on session length and the variety of
+          moments captured rather than a fixed count. The goal is wide coverage — candids, groups,
+          environment, detail — rather than a curated set of portraits.
+        </p>
+      </>
+    )
+  },
+  {
+    question: "What's the payment process?",
+    answer: (
+      <p>
+        A 50% deposit alongside a signed contract is required to guarantee your session date. The
+        remaining balance is due after the shoot, before your final images are delivered.
+        <br />
+        <br />
+        Payment can be made by e-transfer, cash, or cheque. Some exceptions to the payment structure
+        can be made depending on timing and circumstances. Any additional images purchased after
+        your preview gallery will be added to your remaining total.
+      </p>
+    )
+  },
+  {
+    question: 'Do I need to sign a contract?',
+    answer: (
+      <p>
+        Yes. The session agreement is there to make sure we&apos;re on the same page about the
+        details before anything starts. It covers the scope of the shoot, what you&apos;ll receive,
+        timelines, and usage of the images. It&apos;s something we can both reference if any
+        questions come up, and it&apos;s standard for professional photography work. Nothing
+        complicated, just clear expectations for both sides.
+      </p>
+    )
+  },
+  {
+    question: "What's the cancellation policy?",
+    answer: (
+      <p>
+        Cancellations made more than 48 hours before the scheduled session receive a full refund of
+        the deposit, or the deposit can be applied to a rescheduled session. Cancellations within 48
+        hours forfeit the deposit.
+      </p>
+    )
+  },
+  {
+    question: 'Do you travel for sessions?',
+    answer: (
+      <p>
+        Yes. I regularly travel between Kamloops, Vancouver, and Victoria for personal and
+        professional reasons, so depending on where you are, there may be no additional travel cost
+        at all. If you&apos;re in one of those locations, we can likely make something work without
+        a travel fee. For anywhere outside of that, there may be additional costs depending on the
+        location and timing. Reach out and we&apos;ll figure it out.
+      </p>
+    )
+  },
+  {
+    question: 'What should we wear?',
+    answer: (
+      <p>
+        I&apos;m a big believer in capturing life as it actually is, so I&apos;ll always recommend
+        wearing clothes that make you feel like yourself. Whatever you want to be wearing in your
+        photos is the first step in shaping the session. I&apos;m happy to lean into whatever
+        direction you want to take things. If you&apos;d like suggestions, just ask.
+      </p>
+    )
+  },
+  {
+    question: 'How long until we receive the photos?',
+    answer: (
+      <p>
+        Your preview gallery will be ready within 5 days of the session. Once you&apos;ve made your
+        final selections and your remaining balance has been received, the fully edited gallery is
+        delivered within 7 to 10 days.
+        <br />
+        <br />
+        For event sessions, the timeline is similar, though the delivery is a curated set rather
+        than a selection-based gallery.
+      </p>
+    )
+  },
+  {
+    question: 'Can we ask for specific shots?',
+    answer: (
+      <p>
+        Please do. The clearer your vision and requests are, the easier it is to make sure you get
+        what you&apos;re hoping for. I&apos;m always happy to improvise and go with the flow, but a
+        shot list worked out ahead of time means we get everything we&apos;re after and then some.
+      </p>
+    )
+  },
+  {
+    question: "What happens if the weather doesn't cooperate?",
+    answer: (
+      <p>
+        That&apos;s always up to you. There can be something genuinely interesting about capturing
+        moments in weather you didn&apos;t plan for — rain, fog, an overcast sky. If you want to
+        push through, I&apos;m in. And if you&apos;d rather reschedule, we can do that with no
+        penalty.
+      </p>
+    )
+  },
+  {
+    question: "I don't see a package that fits my situation. Can I still reach out?",
+    answer: (
+      <p>
+        Always. The listed packages are starting points. If anything, the unusual or specific
+        circumstances are often the most interesting to work with. Send a message and we&apos;ll
+        figure something out.
+      </p>
+    )
+  }
+];
 
-type FaqAccordionProps = {
-  items: FaqItem[];
-};
-
-export const FaqAccordion = ({ items }: FaqAccordionProps) => {
+export const FaqAccordion = () => {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
 
   const toggle = (index: number) => {
@@ -22,7 +183,7 @@ export const FaqAccordion = ({ items }: FaqAccordionProps) => {
 
   return (
     <dl className="divide-y divide-border">
-      {items.map((item, index) => {
+      {FAQ_ITEMS.map((item, index) => {
         const isOpen = openIndex === index;
 
         return (
@@ -32,7 +193,7 @@ export const FaqAccordion = ({ items }: FaqAccordionProps) => {
                 type="button"
                 onClick={() => toggle(index)}
                 aria-expanded={isOpen}
-                className="flex w-full items-center justify-between gap-4 py-5 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
+                className="flex w-full items-center justify-between gap-4 py-5 text-left focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
               >
                 <span className="text-base font-medium text-ink">{item.question}</span>
                 <ChevronIcon isOpen={isOpen} />
@@ -41,11 +202,13 @@ export const FaqAccordion = ({ items }: FaqAccordionProps) => {
             <dd
               className={cn(
                 'overflow-hidden transition-all duration-standard',
-                isOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+                isOpen ? 'max-h-[500px] opacity-100' : 'max-h-0 opacity-0'
               )}
               aria-hidden={!isOpen}
             >
-              <p className="pb-5 text-base leading-relaxed text-ink-muted">{item.answer}</p>
+              <div className="space-y-4 pb-5 text-base leading-relaxed text-ink-muted">
+                {item.answer}
+              </div>
             </dd>
           </div>
         );

--- a/apps/evrydayarchive-web/app/faq/page.tsx
+++ b/apps/evrydayarchive-web/app/faq/page.tsx
@@ -3,58 +3,10 @@ import Link from 'next/link';
 
 import { FaqAccordion } from './faq-accordion';
 
-const FAQ_ITEMS = [
-  {
-    question: 'What kinds of sessions do you photograph?',
-    answer:
-      'Families, couples, individuals, and everyday life moments — the connective tissue of ordinary days. If it matters to you, it matters to the archive. I also take on select commercial work when the fit is right.'
-  },
-  {
-    question: 'How far in advance should I book?',
-    answer:
-      'A few weeks is usually enough for most sessions. For busy seasons (spring and fall especially) or larger events, a month or two ahead gives us more flexibility with timing and light.'
-  },
-  {
-    question: 'Do you travel for sessions?',
-    answer:
-      "Yes. I'm based in Kamloops, BC and available for travel across Canada. Travel sessions are priced to include logistics — reach out with your location and we'll work out the details."
-  },
-  {
-    question: 'What should we wear / how should we prepare?',
-    answer:
-      "Wear something you'd actually wear on a nice day out. Comfort matters more than coordinated outfits. I'll share a short prep note once we're confirmed — it covers everything from timing to what to bring."
-  },
-  {
-    question: 'How long until we receive the photos?',
-    answer:
-      "Most sessions are delivered within 2–3 weeks. Larger sessions or busy periods may take a little longer. I'll give you a specific timeline when we confirm the booking."
-  },
-  {
-    question: 'How many photos will we receive?',
-    answer:
-      'It depends on the session length and what unfolds — not a fixed number. Quality over quantity is the guiding principle. Every image in your gallery is there because it earned its place.'
-  },
-  {
-    question: 'Can we request specific shots or poses?',
-    answer:
-      "Absolutely. A short list of moments or groups you want documented is always helpful. Beyond that, I'll work in the background and let things breathe. The best images usually come from both."
-  },
-  {
-    question: "What if the weather doesn't cooperate?",
-    answer:
-      "We reschedule, no penalty. Overcast light is often beautiful — but rain, wind, or extreme heat isn't fun for anyone. I'll always be honest if I think we should move the date."
-  },
-  {
-    question: "I don't see a package that fits my situation. Can I still reach out?",
-    answer:
-      "Always. The listed packages are starting points. If your situation is different — unusual hours, a specific location, a larger group, or something entirely different — send a message and we'll figure it out."
-  }
-];
-
 export const metadata: Metadata = {
   title: 'FAQs | Evryday Archive Co',
   description:
-    'Answers to common questions about booking, pricing, turnaround time, and what to expect from your Evryday Archive session.',
+    'Answers to common questions about booking, pricing, turnaround, and what to expect from an Evryday Archive session.',
   alternates: { canonical: '/faq' }
 };
 
@@ -74,7 +26,7 @@ const FaqPage = () => {
             If your question isn&apos;t here,{' '}
             <Link
               href="/inquire"
-              className="font-medium text-ink underline-offset-2 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
+              className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
             >
               just ask
             </Link>
@@ -83,7 +35,7 @@ const FaqPage = () => {
         </header>
 
         {/* Accordion */}
-        <FaqAccordion items={FAQ_ITEMS} />
+        <FaqAccordion />
       </div>
     </main>
   );

--- a/apps/evrydayarchive-web/app/faq/page.tsx
+++ b/apps/evrydayarchive-web/app/faq/page.tsx
@@ -38,23 +38,27 @@ const FaqPage = () => {
         <FaqAccordion />
 
         {/* CTA */}
-        <p className="mt-12 text-base text-ink-muted">
-          Ready to move forward?{' '}
-          <Link
-            href="/inquire"
-            className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
-          >
-            Start an inquiry
-          </Link>{' '}
-          and we&apos;ll go from there. Or take a look at{' '}
-          <Link
-            href="/portfolio"
-            className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
-          >
-            the portfolio
-          </Link>{' '}
-          to see the work first.
-        </p>
+        <div className="mt-12 space-y-1 text-base text-ink-muted">
+          <p>
+            Ready to move forward?{' '}
+            <Link
+              href="/packages"
+              className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            >
+              Pick the package that fits you.
+            </Link>
+          </p>
+          <p>
+            Or take a look at{' '}
+            <Link
+              href="/portfolio"
+              className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            >
+              the portfolio
+            </Link>{' '}
+            to see some of the work.
+          </p>
+        </div>
       </div>
     </main>
   );

--- a/apps/evrydayarchive-web/app/faq/page.tsx
+++ b/apps/evrydayarchive-web/app/faq/page.tsx
@@ -36,6 +36,25 @@ const FaqPage = () => {
 
         {/* Accordion */}
         <FaqAccordion />
+
+        {/* CTA */}
+        <p className="mt-12 text-base text-ink-muted">
+          Ready to move forward?{' '}
+          <Link
+            href="/inquire"
+            className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+          >
+            Start an inquiry
+          </Link>{' '}
+          and we&apos;ll go from there. Or take a look at{' '}
+          <Link
+            href="/portfolio"
+            className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+          >
+            the portfolio
+          </Link>{' '}
+          to see the work first.
+        </p>
       </div>
     </main>
   );

--- a/apps/evrydayarchive-web/app/faq/page.tsx
+++ b/apps/evrydayarchive-web/app/faq/page.tsx
@@ -25,7 +25,7 @@ const FaqPage = () => {
           <p className="mt-5 text-base leading-relaxed text-ink-muted">
             If your question isn&apos;t here,{' '}
             <Link
-              href="/inquire"
+              href="/contact"
               className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
             >
               just ask

--- a/apps/evrydayarchive-web/app/faq/page.tsx
+++ b/apps/evrydayarchive-web/app/faq/page.tsx
@@ -26,7 +26,7 @@ const FaqPage = () => {
             If your question isn&apos;t here,{' '}
             <Link
               href="/contact"
-              className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              className="font-medium text-ink underline underline-offset-2 focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
             >
               just ask
             </Link>
@@ -43,7 +43,7 @@ const FaqPage = () => {
             Ready to move forward?{' '}
             <Link
               href="/packages"
-              className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              className="font-medium text-ink underline underline-offset-2 focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
             >
               Pick the package that fits you.
             </Link>
@@ -52,7 +52,7 @@ const FaqPage = () => {
             Or take a look at{' '}
             <Link
               href="/portfolio"
-              className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              className="font-medium text-ink underline underline-offset-2 focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
             >
               the portfolio
             </Link>{' '}

--- a/apps/evrydayarchive-web/app/packages/page.tsx
+++ b/apps/evrydayarchive-web/app/packages/page.tsx
@@ -48,7 +48,14 @@ const PackagesPage = async () => {
             >
               Get in touch
             </Link>{' '}
-            and we&apos;ll figure something out.
+            and we&apos;ll figure something out. Have questions about pricing or delivery?{' '}
+            <Link
+              href="/faq"
+              className="font-medium text-ink underline-offset-2 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
+            >
+              Check the FAQ
+            </Link>
+            .
           </p>
         </div>
       </section>

--- a/apps/evrydayarchive-web/app/packages/page.tsx
+++ b/apps/evrydayarchive-web/app/packages/page.tsx
@@ -44,14 +44,15 @@ const PackagesPage = async () => {
             Nothing quite fits?{' '}
             <Link
               href="/contact"
-              className="font-medium text-ink underline-offset-2 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
+              className="font-medium text-ink underline underline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
             >
               Get in touch
             </Link>{' '}
-            and we&apos;ll figure something out. Have questions about pricing or delivery?{' '}
+            and we&apos;ll figure something out. <br />
+            Have questions about pricing or delivery?{' '}
             <Link
               href="/faq"
-              className="font-medium text-ink underline-offset-2 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
+              className="font-medium text-ink underline underline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
             >
               Check the FAQ
             </Link>
@@ -70,7 +71,7 @@ const PackagesPage = async () => {
               </p>
               <Link
                 href="/inquire"
-                className="text-sm font-medium text-ink underline-offset-2 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
+                className="text-sm font-medium text-ink underline underline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:rounded-sm"
               >
                 In the meantime, reach out directly →
               </Link>

--- a/apps/evrydayarchive-web/app/page.tsx
+++ b/apps/evrydayarchive-web/app/page.tsx
@@ -160,18 +160,20 @@ export default async function HomePage() {
             Whether you have a session in mind or just want to see if it&apos;s a fit — reach out.
             No pressure, no commitment.
           </p>
-          <Link
-            href="/inquire"
-            className="inline-block rounded-card bg-accent px-8 py-4 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
-          >
-            Start a conversation
-          </Link>
-          <Link
-            href="/process"
-            className="mt-5 inline-flex items-center gap-1 text-sm text-ink-muted transition-[color,transform] duration-fast hover:translate-x-1.5 hover:text-ink"
-          >
-            See how it works →
-          </Link>
+          <div className="flex flex-col items-center gap-3">
+            <Link
+              href="/inquire"
+              className="inline-block rounded-card bg-accent px-8 py-4 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            >
+              Start a conversation
+            </Link>
+            <Link
+              href="/process"
+              className="inline-block rounded-card border border-border px-8 py-4 text-sm font-medium text-ink-muted transition-colors duration-fast hover:border-ink-muted hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            >
+              See how it works
+            </Link>
+          </div>
         </div>
       </section>
     </main>

--- a/apps/evrydayarchive-web/app/page.tsx
+++ b/apps/evrydayarchive-web/app/page.tsx
@@ -160,16 +160,16 @@ export default async function HomePage() {
             Whether you have a session in mind or just want to see if it&apos;s a fit — reach out.
             No pressure, no commitment.
           </p>
-          <div className="flex flex-col items-center gap-3">
+          <div className="flex flex-col gap-3 sm:flex-row">
             <Link
               href="/inquire"
-              className="inline-block rounded-card bg-accent px-8 py-4 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              className="flex-1 rounded-card bg-accent px-8 py-4 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
             >
               Start a conversation
             </Link>
             <Link
               href="/process"
-              className="inline-block rounded-card border border-border px-8 py-4 text-sm font-medium text-ink-muted transition-colors duration-fast hover:border-ink-muted hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              className="flex-1 rounded-card border border-border px-8 py-4 text-sm font-medium text-ink-muted transition-colors duration-fast hover:border-ink-muted hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
             >
               See how it works
             </Link>

--- a/apps/evrydayarchive-web/app/page.tsx
+++ b/apps/evrydayarchive-web/app/page.tsx
@@ -166,6 +166,12 @@ export default async function HomePage() {
           >
             Start a conversation
           </Link>
+          <Link
+            href="/process"
+            className="mt-5 inline-flex items-center gap-1 text-sm text-ink-muted transition-[color,transform] duration-fast hover:translate-x-1.5 hover:text-ink"
+          >
+            See how it works →
+          </Link>
         </div>
       </section>
     </main>

--- a/apps/evrydayarchive-web/app/page.tsx
+++ b/apps/evrydayarchive-web/app/page.tsx
@@ -160,16 +160,16 @@ export default async function HomePage() {
             Whether you have a session in mind or just want to see if it&apos;s a fit — reach out.
             No pressure, no commitment.
           </p>
-          <div className="flex flex-col gap-3 sm:flex-row">
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
             <Link
               href="/inquire"
-              className="flex-1 rounded-card bg-accent px-8 py-4 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              className="w-full rounded-card bg-accent px-6 py-3 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent sm:w-auto"
             >
               Start a conversation
             </Link>
             <Link
               href="/process"
-              className="flex-1 rounded-card border border-border px-8 py-4 text-sm font-medium text-ink-muted transition-colors duration-fast hover:border-ink-muted hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+              className="w-full rounded-card border border-border px-6 py-3 text-sm font-medium text-ink-muted transition-colors duration-fast hover:border-ink-muted hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent sm:w-auto"
             >
               See how it works
             </Link>

--- a/apps/evrydayarchive-web/app/page.tsx
+++ b/apps/evrydayarchive-web/app/page.tsx
@@ -163,13 +163,13 @@ export default async function HomePage() {
           <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
             <Link
               href="/inquire"
-              className="w-full rounded-card bg-accent px-6 py-3 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent sm:w-auto"
+              className="rounded-card bg-accent px-6 py-3 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
             >
               Start a conversation
             </Link>
             <Link
               href="/process"
-              className="w-full rounded-card border border-border px-6 py-3 text-sm font-medium text-ink-muted transition-colors duration-fast hover:border-ink-muted hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent sm:w-auto"
+              className="rounded-card border border-border px-6 py-3 text-sm font-medium text-ink-muted transition-colors duration-fast hover:border-ink-muted hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
             >
               See how it works
             </Link>

--- a/apps/evrydayarchive-web/app/page.tsx
+++ b/apps/evrydayarchive-web/app/page.tsx
@@ -160,7 +160,7 @@ export default async function HomePage() {
             Whether you have a session in mind or just want to see if it&apos;s a fit — reach out.
             No pressure, no commitment.
           </p>
-          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+          <div className="inline-grid grid-cols-1 gap-3 sm:grid-cols-2">
             <Link
               href="/inquire"
               className="rounded-card bg-accent px-6 py-3 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"

--- a/apps/evrydayarchive-web/app/process/page.tsx
+++ b/apps/evrydayarchive-web/app/process/page.tsx
@@ -41,7 +41,7 @@ const ProcessPage = () => {
           </Link>{' '}
           covers most of them. Or just{' '}
           <Link
-            href="/inquire"
+            href="/contact"
             className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
           >
             reach out

--- a/apps/evrydayarchive-web/app/process/page.tsx
+++ b/apps/evrydayarchive-web/app/process/page.tsx
@@ -35,14 +35,14 @@ const ProcessPage = () => {
           Still have questions? The{' '}
           <Link
             href="/faq"
-            className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            className="font-medium text-ink underline underline-offset-2 focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
           >
             FAQ
           </Link>{' '}
           covers most of them. Or just{' '}
           <Link
             href="/contact"
-            className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            className="font-medium text-ink underline underline-offset-2 focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
           >
             reach out
           </Link>{' '}

--- a/apps/evrydayarchive-web/app/process/page.tsx
+++ b/apps/evrydayarchive-web/app/process/page.tsx
@@ -1,44 +1,11 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
-import { Placard } from '../components/placard';
-
-const STEPS = [
-  {
-    number: '01',
-    title: 'Reach out',
-    description:
-      'Send a message with a rough idea of what you have in mind. No formal brief needed — just tell me the occasion, the people, and what feels important to you.'
-  },
-  {
-    number: '02',
-    title: 'We talk it through',
-    description:
-      'A short conversation to make sure we understand each other. I want to know what success looks like for you, and you should feel comfortable knowing what to expect from the day.'
-  },
-  {
-    number: '03',
-    title: 'The session',
-    description:
-      "We meet, we document. My job is to stay out of the way and let things unfold. There's no forced posing — just good light, honest moments, and time well spent."
-  },
-  {
-    number: '04',
-    title: 'Editing & delivery',
-    description:
-      'I work through the images carefully. Every photo that makes the cut is edited with intention — not over-processed, not undercooked. You receive a private gallery within the agreed timeline.'
-  },
-  {
-    number: '05',
-    title: 'After the archive',
-    description:
-      'The gallery is yours. Print, share, keep. If you want prints or albums arranged, I can help. And if you come back for another session someday, all the better.'
-  }
-];
+import { ProcessAccordion } from './process-accordion';
 
 export const metadata: Metadata = {
   title: 'How It Works | Evryday Archive Co',
-  description:
-    'From first inquiry to final gallery — here is how Reed McIlwain documents your everyday life from start to finish.',
+  description: "From first message to finished gallery — here's what working together looks like.",
   alternates: { canonical: '/process' }
 };
 
@@ -55,37 +22,32 @@ const ProcessPage = () => {
             The process
           </h1>
           <p className="mt-5 max-w-lg text-base leading-relaxed text-ink-muted">
-            Simple, clear, and low-pressure. Here&apos;s what working together looks like from first
-            message to finished archive.
+            Simple, honest, and low-pressure. Here&apos;s what working together actually looks like,
+            from first message to finished archive.
           </p>
         </header>
 
-        {/* Steps */}
-        <ol className="space-y-12">
-          {STEPS.map((step, index) => (
-            <li key={step.number} className="flex gap-6 sm:gap-10">
-              {/* Step number */}
-              <div className="flex-none pt-1">
-                <Placard title={step.number} size="sm" />
-              </div>
+        {/* Accordion */}
+        <ProcessAccordion />
 
-              {/* Step content */}
-              <div className="flex-1">
-                {/* Connector line (except last) */}
-                <div className="relative">
-                  {index < STEPS.length - 1 && (
-                    <div
-                      className="absolute left-[-2.75rem] top-8 hidden h-full w-px bg-border sm:left-[-3.5rem] sm:block"
-                      aria-hidden="true"
-                    />
-                  )}
-                </div>
-                <h2 className="mb-2 text-lg font-semibold text-ink">{step.title}</h2>
-                <p className="text-base leading-relaxed text-ink-muted">{step.description}</p>
-              </div>
-            </li>
-          ))}
-        </ol>
+        {/* CTA */}
+        <p className="mt-12 text-base text-ink-muted">
+          Still have questions? The{' '}
+          <Link
+            href="/faq"
+            className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+          >
+            FAQ
+          </Link>{' '}
+          covers most of them. Or just{' '}
+          <Link
+            href="/inquire"
+            className="font-medium text-ink underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+          >
+            reach out
+          </Link>{' '}
+          directly.
+        </p>
       </div>
     </main>
   );

--- a/apps/evrydayarchive-web/app/process/process-accordion.tsx
+++ b/apps/evrydayarchive-web/app/process/process-accordion.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useState } from 'react';
+
+import { cn } from '../lib/cn';
+
+const STEPS = [
+  {
+    number: '01',
+    title: 'Reach out',
+    summary: 'Send a message with a rough idea of what you have in mind.',
+    detail: (
+      <p>
+        No formal brief needed. Just tell me the occasion, the people involved, and what feels
+        important to you. If you&apos;re not sure which package fits, that&apos;s fine. We&apos;ll
+        figure it out together. You can reach out through the inquiry form or by sending a DM on
+        Instagram.
+      </p>
+    )
+  },
+  {
+    number: '02',
+    title: 'We get aligned',
+    summary: 'A short conversation before anything is confirmed.',
+    detail: (
+      <>
+        <p>
+          For most sessions, this is a quick message exchange to clarify the date, location, and
+          what you&apos;re hoping to walk away with. For In Practice sessions (small business and
+          professional work), this includes a dedicated 60-minute alignment call over Zoom or in
+          person. It&apos;s a chance to make sure I understand the purpose of the shoot and you know
+          what to expect from the day.
+        </p>
+        <p>
+          Once we&apos;re aligned, I&apos;ll send over a session agreement that outlines the
+          details: date, deliverables, pricing, and image usage. A 50% deposit is required alongside
+          the signed agreement to confirm your booking. The remainder is due after the shoot, before
+          your final images are delivered.
+        </p>
+      </>
+    )
+  },
+  {
+    number: '03',
+    title: 'The session',
+    summary: 'We meet, we document. My job is to stay out of the way.',
+    detail: (
+      <>
+        <p>
+          Sessions are low-pressure by design. The ideal version is you doing what you love, or
+          spending time with the people you love, in a way that feels normal. I get out of the way
+          and quietly capture what&apos;s there.
+        </p>
+        <p>
+          That said, I&apos;m always present and ready to jump in. I&apos;ll use the space and
+          environment we&apos;re in to find interesting angles and compositions, and I&apos;ll
+          direct and pose when it helps — the goal is just to make sure it never feels awkward.
+          Keeping things moving and making the most of our time together is part of the job.
+        </p>
+      </>
+    )
+  },
+  {
+    number: '04',
+    title: 'Preview gallery',
+    summary: "Within 5 days, you'll receive a private gallery to review.",
+    detail: (
+      <>
+        <p>
+          After the session, I work through everything and build a lightly edited preview gallery.
+          You&apos;ll receive a private link, usually within 5 days, and from there you select the
+          images you want fully edited.
+        </p>
+        <p>
+          Each package includes a set number of images. You can select fewer if you want, or add
+          more at $7 per image. Take your time with the gallery.
+        </p>
+        <p>
+          <strong className="font-medium text-ink">
+            Exception — As It Unfolds (event coverage):
+          </strong>{' '}
+          Event sessions skip the preview gallery entirely. Instead, I deliver a curated final
+          gallery based on the session length and the range of moments captured. The goal is wide
+          coverage: group shots, candids, environment, and detail. There&apos;s no selection step.
+        </p>
+      </>
+    )
+  },
+  {
+    number: '05',
+    title: 'Final delivery',
+    summary: 'Final edited images delivered within 7 to 10 days of your selections.',
+    detail: (
+      <>
+        <p>
+          Once you&apos;ve made your selections and the remaining balance has been received, I get
+          to work on the final edits. Every image in your gallery is edited with intention:
+          consistent, clean, and honest to how the day looked and felt.
+        </p>
+        <p>
+          Your finished gallery will be delivered as a private online gallery within 7 to 10 days.
+          From there, it&apos;s yours. Download, print, share, keep. If you want help arranging
+          prints or albums, I&apos;m happy to point you in the right direction.
+        </p>
+        <p>
+          And if you come back for another session down the road, good. That&apos;s how this is
+          supposed to work.
+        </p>
+      </>
+    )
+  }
+];
+
+export const ProcessAccordion = () => {
+  const [openIndex, setOpenIndex] = useState<number>(0);
+
+  const toggle = (index: number) => {
+    setOpenIndex((prev) => (prev === index ? -1 : index));
+  };
+
+  return (
+    <ol className="divide-y divide-border">
+      {STEPS.map((step, index) => {
+        const isOpen = openIndex === index;
+
+        return (
+          <li key={step.number}>
+            <button
+              type="button"
+              onClick={() => toggle(index)}
+              aria-expanded={isOpen}
+              className="flex w-full items-center gap-5 py-5 text-left focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+            >
+              <span className="w-7 flex-none text-xs font-medium tabular-nums text-ink-faint">
+                {step.number}
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-base font-medium text-ink">{step.title}</p>
+                <p className="mt-0.5 text-sm text-ink-muted">{step.summary}</p>
+              </div>
+              <ChevronIcon isOpen={isOpen} />
+            </button>
+            <div
+              className={cn(
+                'overflow-hidden transition-all duration-standard',
+                isOpen ? 'max-h-[600px] opacity-100' : 'max-h-0 opacity-0'
+              )}
+              aria-hidden={!isOpen}
+            >
+              <div className="space-y-4 pb-6 pl-12 text-base leading-relaxed text-ink-muted">
+                {step.detail}
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+};
+
+const ChevronIcon = ({ isOpen }: { isOpen: boolean }) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    aria-hidden="true"
+    className={cn(
+      'flex-none text-ink-faint transition-transform duration-fast',
+      isOpen && 'rotate-180'
+    )}
+  >
+    <path
+      d="M4 6l4 4 4-4"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);


### PR DESCRIPTION
## Summary

- **Process page**: replaces the static numbered list with an interactive accordion (Step 1 open by default); rewrites all five step descriptions with new copy; updates metadata description
- **FAQ page**: expands from 9 to 12 questions (adds payment process, contract, and cancellation entries); updates accordion to support multi-paragraph and bold text answers; updates metadata; adds bottom CTA linking to `/packages` and `/portfolio`
- **Footer**: adds Process and FAQ links to the footer nav
- **Cross-links**: adds contextual links to `/process` and `/faq` from the home page final CTA, packages intro, and about page closing CTA
- **Consistency fixes**: inline prose links are now always underlined (not just on hover); about page "Get in touch" button updated to `rounded-card` to match site-wide button style

## Test plan

- [x] `/process` — accordion opens/closes correctly; Step 1 is open on load; bottom CTA links go to `/faq` and `/contact`
- [x] `/faq` — all 12 questions present and expand correctly; top link goes to `/contact`; bottom CTA links go to `/packages` and `/portfolio`
- [x] Footer — Process and FAQ links visible and correct on all pages
- [x] Home page — final CTA buttons stack on mobile, sit side-by-side on desktop, equal width; "See how it works" links to `/process`
- [x] Packages page — FAQ link in intro text is underlined and goes to `/faq`
- [x] About page — "See how it works →" link present below CTA on mobile and desktop; button uses `rounded-card`
- [x] Inline text links on process, faq, packages pages are underlined by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)