### PR TITLE
Add password-gated private galleries for unlisted sharing

### DIFF
--- a/apps/admin/app/api/galleries/[id]/access-log/route.ts
+++ b/apps/admin/app/api/galleries/[id]/access-log/route.ts
@@ -1,0 +1,30 @@
+import { prisma } from '@repo/db';
+
+import { jsonOk } from '@repo/core';
+import { requireAdminSession } from '../../../../lib/auth';
+
+export const GET = async (
+  req: Request,
+  { params }: { params: { id: string } }
+): Promise<Response> => {
+  const authError = requireAdminSession(req);
+  if (authError) {
+    return authError;
+  }
+
+  const logs = await prisma.galleryAccessLog.findMany({
+    where: { galleryId: params.id },
+    orderBy: { createdAt: 'desc' },
+    take: 25
+  });
+
+  return jsonOk(
+    logs.map((log) => ({
+      id: log.id,
+      success: log.success,
+      ipAddress: log.ipAddress,
+      userAgent: log.userAgent,
+      createdAt: log.createdAt.toISOString()
+    }))
+  );
+};

--- a/apps/admin/app/api/galleries/[id]/publish/route.ts
+++ b/apps/admin/app/api/galleries/[id]/publish/route.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from 'node:crypto';
+
 import { PrismaClientKnownRequestError, prisma } from '@repo/db';
 
 import { GalleryPublishSchema, createApiError, jsonError, jsonOk, parseJson } from '@repo/core';
@@ -20,15 +22,30 @@ export const POST = async (
 
   try {
     const publishedAt = result.data.status === 'PUBLISHED' ? new Date() : null;
+
+    let accessToken: string | undefined;
+    if (result.data.status === 'PRIVATE') {
+      const existing = await prisma.gallery.findUnique({
+        where: { id: params.id },
+        select: { accessToken: true }
+      });
+      accessToken = existing?.accessToken ?? randomBytes(9).toString('base64url');
+    }
+
     const gallery = await prisma.gallery.update({
       where: { id: params.id },
       data: {
         status: result.data.status,
-        publishedAt
+        publishedAt,
+        ...(accessToken ? { accessToken } : {})
       }
     });
 
-    return jsonOk({ status: gallery.status, publishedAt: gallery.publishedAt });
+    return jsonOk({
+      status: gallery.status,
+      publishedAt: gallery.publishedAt,
+      accessToken: gallery.accessToken
+    });
   } catch (error) {
     if (error instanceof PrismaClientKnownRequestError && error.code === 'P2025') {
       return jsonError(createApiError('NOT_FOUND', 'Gallery not found.'));

--- a/apps/admin/app/api/galleries/[id]/route.ts
+++ b/apps/admin/app/api/galleries/[id]/route.ts
@@ -2,6 +2,7 @@ import { PrismaClientKnownRequestError, prisma } from '@repo/db';
 
 import { GalleryUpdateSchema, createApiError, jsonError, jsonOk, parseJson } from '@repo/core';
 import { requireAdminSession } from '../../../lib/auth';
+import { hashPassword } from '../../../lib/password';
 
 export const GET = async (
   req: Request,
@@ -26,7 +27,9 @@ export const GET = async (
     return jsonError(createApiError('NOT_FOUND', 'Gallery not found.'));
   }
 
-  return jsonOk(gallery);
+  const { passwordHash: _passwordHash, ...galleryWithoutPasswordHash } = gallery;
+
+  return jsonOk({ ...galleryWithoutPasswordHash, hasPassword: !!gallery.passwordHash });
 };
 
 export const PUT = async (
@@ -44,13 +47,20 @@ export const PUT = async (
     return jsonError(result.error);
   }
 
+  const { password, ...rest } = result.data;
+
   try {
     const gallery = await prisma.gallery.update({
       where: { id: params.id },
-      data: result.data
+      data: {
+        ...rest,
+        ...(password ? { passwordHash: hashPassword(password) } : {})
+      }
     });
 
-    return jsonOk(gallery);
+    const { passwordHash: _passwordHash, ...galleryWithoutPasswordHash } = gallery;
+
+    return jsonOk({ ...galleryWithoutPasswordHash, hasPassword: !!gallery.passwordHash });
   } catch (error) {
     if (error instanceof PrismaClientKnownRequestError) {
       if (error.code === 'P2025') {

--- a/apps/admin/app/api/galleries/route.ts
+++ b/apps/admin/app/api/galleries/route.ts
@@ -2,6 +2,7 @@ import { PrismaClientKnownRequestError, prisma } from '@repo/db';
 
 import { GalleryCreateSchema, createApiError, jsonError, jsonOk, parseJson } from '@repo/core';
 import { requireAdminSession } from '../../lib/auth';
+import { hashPassword } from '../../lib/password';
 
 export const GET = async (req: Request): Promise<Response> => {
   const authError = requireAdminSession(req);
@@ -20,7 +21,12 @@ export const GET = async (req: Request): Promise<Response> => {
     }
   });
 
-  return jsonOk(galleries);
+  const sanitized = galleries.map(({ passwordHash, ...gallery }) => ({
+    ...gallery,
+    hasPassword: !!passwordHash
+  }));
+
+  return jsonOk(sanitized);
 };
 
 export const POST = async (req: Request): Promise<Response> => {
@@ -35,15 +41,23 @@ export const POST = async (req: Request): Promise<Response> => {
     return jsonError(result.error);
   }
 
+  const { password, ...rest } = result.data;
+
   try {
     const gallery = await prisma.gallery.create({
       data: {
-        ...result.data,
-        status: 'DRAFT'
+        ...rest,
+        status: 'DRAFT',
+        ...(password ? { passwordHash: hashPassword(password) } : {})
       }
     });
 
-    return jsonOk(gallery, { status: 201 });
+    const { passwordHash: _passwordHash, ...galleryWithoutPasswordHash } = gallery;
+
+    return jsonOk(
+      { ...galleryWithoutPasswordHash, hasPassword: !!gallery.passwordHash },
+      { status: 201 }
+    );
   } catch (error) {
     if (error instanceof PrismaClientKnownRequestError && error.code === 'P2002') {
       return jsonError(createApiError('CONFLICT', 'Gallery slug already exists.'));

--- a/apps/admin/app/api/public/private-galleries/[token]/private-gallery-get.route.test.ts
+++ b/apps/admin/app/api/public/private-galleries/[token]/private-gallery-get.route.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  galleryFindFirst: vi.fn(),
+  verifyGalleryAccessToken: vi.fn()
+}));
+
+vi.mock('@repo/db', () => ({
+  prisma: {
+    gallery: { findFirst: mocks.galleryFindFirst }
+  }
+}));
+
+vi.mock('../../../../lib/auth', () => ({
+  verifyGalleryAccessToken: mocks.verifyGalleryAccessToken
+}));
+
+const makeRequest = (authorization?: string) =>
+  new Request('http://localhost/api/public/private-galleries/tok_1', {
+    headers: authorization ? { authorization } : {}
+  });
+
+describe('GET /api/public/private-galleries/[token]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('rejects requests with no bearer token', async () => {
+    mocks.verifyGalleryAccessToken.mockReturnValueOnce(null);
+
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest(), { params: { token: 'tok_1' } });
+
+    expect(response.status).toBe(401);
+    expect(mocks.galleryFindFirst).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests with an invalid or expired token', async () => {
+    mocks.verifyGalleryAccessToken.mockReturnValueOnce(null);
+
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest('Bearer bad.token'), { params: { token: 'tok_1' } });
+
+    expect(response.status).toBe(401);
+    expect(mocks.galleryFindFirst).not.toHaveBeenCalled();
+  });
+
+  it('returns the gallery detail for a valid token', async () => {
+    mocks.verifyGalleryAccessToken.mockReturnValueOnce('gal_1');
+    mocks.galleryFindFirst.mockResolvedValueOnce({
+      id: 'gal_1',
+      accessToken: 'tok_1',
+      title: 'Acme Co Preview',
+      description: null,
+      location: null,
+      images: [
+        {
+          id: 'img_1',
+          order: 0,
+          imageAsset: {
+            src: 'https://res.cloudinary.com/demo/image/upload/sample.jpg',
+            alt: 'A sample photo',
+            caption: null,
+            width: 1200,
+            height: 800
+          }
+        }
+      ]
+    });
+
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest('Bearer good.token'), { params: { token: 'tok_1' } });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.title).toBe('Acme Co Preview');
+    expect(payload.images[0]).toMatchObject({ id: 'img_1', src: expect.any(String) });
+    expect(mocks.galleryFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'gal_1', accessToken: 'tok_1', status: 'PRIVATE' }
+      })
+    );
+  });
+
+  it('returns 404 when the token verifies but the gallery no longer matches', async () => {
+    mocks.verifyGalleryAccessToken.mockReturnValueOnce('gal_1');
+    mocks.galleryFindFirst.mockResolvedValueOnce(null);
+
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest('Bearer good.token'), { params: { token: 'tok_1' } });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/admin/app/api/public/private-galleries/[token]/route.ts
+++ b/apps/admin/app/api/public/private-galleries/[token]/route.ts
@@ -1,0 +1,71 @@
+import { PrivateGalleryDetailSchema } from '@repo/core';
+import { prisma } from '@repo/db';
+
+import { verifyGalleryAccessToken } from '../../../../lib/auth';
+
+type GalleryImageWithAsset = {
+  id: string;
+  order: number;
+  imageAsset: {
+    src: string;
+    alt: string | null;
+    caption: string | null;
+    width: number | null;
+    height: number | null;
+  };
+};
+
+const getBearerToken = (req: Request): string | null => {
+  const header = req.headers.get('authorization');
+  if (!header?.startsWith('Bearer ')) {
+    return null;
+  }
+  return header.slice('Bearer '.length).trim();
+};
+
+export const GET = async (
+  req: Request,
+  { params }: { params: { token: string } }
+): Promise<Response> => {
+  const bearerToken = getBearerToken(req);
+  const galleryId = verifyGalleryAccessToken(bearerToken, params.token);
+
+  if (!galleryId) {
+    return Response.json({ message: 'Unauthorized.' }, { status: 401 });
+  }
+
+  const gallery = await prisma.gallery.findFirst({
+    where: { id: galleryId, accessToken: params.token, status: 'PRIVATE' },
+    include: {
+      images: {
+        include: { imageAsset: true },
+        orderBy: { order: 'asc' }
+      }
+    }
+  });
+
+  if (!gallery) {
+    return Response.json({ message: 'Gallery not found.' }, { status: 404 });
+  }
+
+  const responsePayload = {
+    id: gallery.id,
+    accessToken: gallery.accessToken,
+    title: gallery.title,
+    description: gallery.description,
+    location: gallery.location,
+    images: gallery.images.map((image: GalleryImageWithAsset) => ({
+      id: image.id,
+      order: image.order,
+      src: image.imageAsset.src,
+      alt: image.imageAsset.alt,
+      caption: image.imageAsset.caption,
+      width: image.imageAsset.width,
+      height: image.imageAsset.height
+    }))
+  };
+
+  const payload = PrivateGalleryDetailSchema.parse(responsePayload);
+
+  return Response.json(payload);
+};

--- a/apps/admin/app/api/public/private-galleries/[token]/verify/private-gallery-verify.route.test.ts
+++ b/apps/admin/app/api/public/private-galleries/[token]/verify/private-gallery-verify.route.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  galleryFindFirst: vi.fn(),
+  accessLogCount: vi.fn(),
+  accessLogCreate: vi.fn(),
+  verifyPassword: vi.fn(),
+  createGalleryAccessToken: vi.fn()
+}));
+
+vi.mock('@repo/db', () => ({
+  prisma: {
+    gallery: { findFirst: mocks.galleryFindFirst },
+    galleryAccessLog: { count: mocks.accessLogCount, create: mocks.accessLogCreate }
+  }
+}));
+
+vi.mock('../../../../../lib/password', () => ({
+  verifyPassword: mocks.verifyPassword
+}));
+
+vi.mock('../../../../../lib/auth', () => ({
+  createGalleryAccessToken: mocks.createGalleryAccessToken
+}));
+
+const makeRequest = (password: unknown) =>
+  new Request('http://localhost/api/public/private-galleries/tok_1/verify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-forwarded-for': '203.0.113.5' },
+    body: JSON.stringify({ password })
+  });
+
+describe('POST /api/public/private-galleries/[token]/verify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mocks.accessLogCount.mockResolvedValue(0);
+  });
+
+  it('returns 404 when no private gallery matches the token', async () => {
+    mocks.galleryFindFirst.mockResolvedValueOnce(null);
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest('secret'), { params: { token: 'tok_1' } });
+    const payload = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(payload.ok).toBe(false);
+  });
+
+  it('logs a failed attempt and rejects an incorrect password', async () => {
+    mocks.galleryFindFirst.mockResolvedValueOnce({
+      id: 'gal_1',
+      accessToken: 'tok_1',
+      passwordHash: 'salt:hash'
+    });
+    mocks.verifyPassword.mockReturnValueOnce(false);
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest('wrong'), { params: { token: 'tok_1' } });
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload.ok).toBe(false);
+    expect(mocks.accessLogCreate).toHaveBeenCalledWith({
+      data: { galleryId: 'gal_1', success: false, ipAddress: '203.0.113.5', userAgent: null }
+    });
+    expect(mocks.createGalleryAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('logs a success and returns a signed access token for the correct password', async () => {
+    mocks.galleryFindFirst.mockResolvedValueOnce({
+      id: 'gal_1',
+      accessToken: 'tok_1',
+      passwordHash: 'salt:hash'
+    });
+    mocks.verifyPassword.mockReturnValueOnce(true);
+    mocks.createGalleryAccessToken.mockReturnValueOnce('signed.token');
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest('correct'), { params: { token: 'tok_1' } });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ ok: true, data: { token: 'signed.token' } });
+    expect(mocks.accessLogCreate).toHaveBeenCalledWith({
+      data: { galleryId: 'gal_1', success: true, ipAddress: '203.0.113.5', userAgent: null }
+    });
+    expect(mocks.createGalleryAccessToken).toHaveBeenCalledWith('gal_1', 'tok_1');
+  });
+
+  it('rejects with 429 once the recent-failure lockout threshold is reached', async () => {
+    mocks.galleryFindFirst.mockResolvedValueOnce({
+      id: 'gal_1',
+      accessToken: 'tok_1',
+      passwordHash: 'salt:hash'
+    });
+    mocks.accessLogCount.mockResolvedValueOnce(10);
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest('correct'), { params: { token: 'tok_1' } });
+    const payload = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(payload.ok).toBe(false);
+    expect(mocks.verifyPassword).not.toHaveBeenCalled();
+    expect(mocks.accessLogCreate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/app/api/public/private-galleries/[token]/verify/route.ts
+++ b/apps/admin/app/api/public/private-galleries/[token]/verify/route.ts
@@ -1,0 +1,72 @@
+import { prisma } from '@repo/db';
+
+import {
+  PrivateGalleryVerifySchema,
+  createApiError,
+  jsonError,
+  jsonOk,
+  parseJson
+} from '@repo/core';
+import { createGalleryAccessToken } from '../../../../../lib/auth';
+import { verifyPassword } from '../../../../../lib/password';
+
+const LOCKOUT_WINDOW_MS = 1000 * 60 * 15;
+const LOCKOUT_MAX_FAILURES = 10;
+
+const getClientIp = (req: Request): string | null => {
+  const forwardedFor = req.headers.get('x-forwarded-for');
+  if (!forwardedFor) {
+    return null;
+  }
+  return forwardedFor.split(',')[0]?.trim() ?? null;
+};
+
+export const POST = async (
+  req: Request,
+  { params }: { params: { token: string } }
+): Promise<Response> => {
+  const result = await parseJson(req, PrivateGalleryVerifySchema);
+
+  if (!result.ok) {
+    return jsonError(result.error);
+  }
+
+  const gallery = await prisma.gallery.findFirst({
+    where: { accessToken: params.token, status: 'PRIVATE' }
+  });
+
+  if (!gallery || !gallery.passwordHash) {
+    return jsonError(createApiError('NOT_FOUND', 'Gallery not found.'));
+  }
+
+  const ipAddress = getClientIp(req);
+  const userAgent = req.headers.get('user-agent');
+
+  const recentFailures = await prisma.galleryAccessLog.count({
+    where: {
+      galleryId: gallery.id,
+      success: false,
+      createdAt: { gte: new Date(Date.now() - LOCKOUT_WINDOW_MS) }
+    }
+  });
+
+  if (recentFailures >= LOCKOUT_MAX_FAILURES) {
+    return jsonError(
+      createApiError('TOO_MANY_REQUESTS', 'Too many failed attempts. Please try again later.')
+    );
+  }
+
+  const success = verifyPassword(result.data.password, gallery.passwordHash);
+
+  await prisma.galleryAccessLog.create({
+    data: { galleryId: gallery.id, success, ipAddress, userAgent }
+  });
+
+  if (!success) {
+    return jsonError(createApiError('UNAUTHORIZED', 'Incorrect password.'));
+  }
+
+  const token = createGalleryAccessToken(gallery.id, gallery.accessToken as string);
+
+  return jsonOk({ token });
+};

--- a/apps/admin/app/galleries/[id]/page.tsx
+++ b/apps/admin/app/galleries/[id]/page.tsx
@@ -21,6 +21,9 @@ const GalleryDetailPage = async ({ params }: { params: { id: string } }) => {
     notFound();
   }
 
+  const { passwordHash, ...galleryWithoutPasswordHash } = gallery;
+  const galleryForEditor = { ...galleryWithoutPasswordHash, hasPassword: !!passwordHash };
+
   return (
     <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-6 px-6 py-16">
       <header>
@@ -31,7 +34,7 @@ const GalleryDetailPage = async ({ params }: { params: { id: string } }) => {
         <p className="text-sm text-slate-500">Edit gallery settings and images.</p>
       </header>
 
-      <GalleryEditor gallery={gallery} />
+      <GalleryEditor gallery={galleryForEditor} />
     </main>
   );
 };

--- a/apps/admin/app/galleries/components/GalleryEditor.tsx
+++ b/apps/admin/app/galleries/components/GalleryEditor.tsx
@@ -19,8 +19,18 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { useToast } from '../../components/Toaster';
 
-const statusOptions = ['DRAFT', 'PUBLISHED', 'ARCHIVED'] as const;
+const statusOptions = ['DRAFT', 'PUBLISHED', 'ARCHIVED', 'PRIVATE'] as const;
 type GalleryStatus = (typeof statusOptions)[number];
+
+const PUBLIC_SITE_URL = 'https://www.evrydayarchive.co';
+
+type AccessLogEntry = {
+  id: string;
+  success: boolean;
+  ipAddress: string | null;
+  userAgent: string | null;
+  createdAt: string;
+};
 
 type ImageAsset = {
   id: string;
@@ -48,6 +58,8 @@ type Gallery = {
   order: number;
   featured: boolean;
   images: GalleryImage[];
+  accessToken: string | null;
+  hasPassword: boolean;
 };
 
 type UploadItem = {
@@ -141,6 +153,10 @@ const GalleryEditor = ({ gallery }: { gallery: Gallery }) => {
   const [uploading, setUploading] = useState(false);
   const [orderDirty, setOrderDirty] = useState(false);
   const [savingOrder, setSavingOrder] = useState(false);
+  const [passwordInput, setPasswordInput] = useState('');
+  const [savingPassword, setSavingPassword] = useState(false);
+  const [accessLog, setAccessLog] = useState<AccessLogEntry[] | null>(null);
+  const [loadingAccessLog, setLoadingAccessLog] = useState(false);
 
   const sensors = useSensors(useSensor(PointerSensor));
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -188,8 +204,62 @@ const GalleryEditor = ({ gallery }: { gallery: Gallery }) => {
       return;
     }
 
-    setGalleryState((prev) => ({ ...prev, status: payload.data.status }));
+    setGalleryState((prev) => ({
+      ...prev,
+      status: payload.data.status,
+      accessToken: payload.data.accessToken ?? prev.accessToken
+    }));
     addToast('Status updated.', 'success');
+  };
+
+  // ── Private gallery: password + access log ──────────────────────────────────
+
+  const savePassword = async () => {
+    if (!passwordInput) return;
+
+    setSavingPassword(true);
+    const response = await fetch(`/api/galleries/${gallery.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: passwordInput })
+    });
+
+    const payload = await response.json();
+    setSavingPassword(false);
+    if (!payload.ok) {
+      addToast(payload.error?.message ?? 'Unable to set password.', 'error');
+      return;
+    }
+
+    setGalleryState((prev) => ({ ...prev, hasPassword: true }));
+    setPasswordInput('');
+    addToast('Password updated.', 'success');
+  };
+
+  const generatePassword = () => {
+    const bytes = new Uint8Array(9);
+    crypto.getRandomValues(bytes);
+    const generated = btoa(String.fromCharCode(...bytes))
+      .replace(/[+/=]/g, '')
+      .slice(0, 12);
+    setPasswordInput(generated);
+  };
+
+  const copyShareUrl = async (accessToken: string) => {
+    await navigator.clipboard.writeText(`${PUBLIC_SITE_URL}/private/${accessToken}`);
+    addToast('Share URL copied.', 'success');
+  };
+
+  const loadAccessLog = async () => {
+    setLoadingAccessLog(true);
+    const response = await fetch(`/api/galleries/${gallery.id}/access-log`);
+    const payload = await response.json();
+    setLoadingAccessLog(false);
+    if (!payload.ok) {
+      addToast(payload.error?.message ?? 'Unable to load access log.', 'error');
+      return;
+    }
+    setAccessLog(payload.data);
   };
 
   // ── Upload queue ─────────────────────────────────────────────────────────────
@@ -497,6 +567,93 @@ const GalleryEditor = ({ gallery }: { gallery: Gallery }) => {
           <span className="text-sm text-slate-500">Current: {galleryState.status}</span>
         </div>
       </section>
+
+      {/* Private gallery sharing */}
+      {galleryState.status === 'PRIVATE' && (
+        <section className="rounded-lg border border-slate-200 bg-white p-6">
+          <h2 className="text-lg font-semibold text-slate-900">Private sharing</h2>
+          <p className="mt-1 text-sm text-slate-500">
+            This gallery is only reachable at the link below, and only after the password is
+            entered. It is excluded from the public site, sitemap, and search engines.
+          </p>
+
+          {galleryState.accessToken && (
+            <div className="mt-4 flex items-center gap-2">
+              <input
+                readOnly
+                value={`${PUBLIC_SITE_URL}/private/${galleryState.accessToken}`}
+                className="flex-1 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700"
+              />
+              <button
+                type="button"
+                onClick={() => copyShareUrl(galleryState.accessToken as string)}
+                className="rounded-md border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+              >
+                Copy
+              </button>
+            </div>
+          )}
+
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <input
+              type="text"
+              value={passwordInput}
+              onChange={(e) => setPasswordInput(e.target.value)}
+              placeholder={galleryState.hasPassword ? 'Set a new password' : 'Set a password'}
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm"
+            />
+            <button
+              type="button"
+              onClick={generatePassword}
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+            >
+              Generate
+            </button>
+            <button
+              type="button"
+              onClick={savePassword}
+              disabled={!passwordInput || savingPassword}
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:bg-indigo-300"
+            >
+              {savingPassword ? 'Saving…' : 'Save password'}
+            </button>
+            <span className="text-sm text-slate-500">
+              {galleryState.hasPassword ? 'Password is set.' : 'No password set yet.'}
+            </span>
+          </div>
+
+          <div className="mt-6">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-slate-900">Recent access attempts</h3>
+              <button
+                type="button"
+                onClick={loadAccessLog}
+                disabled={loadingAccessLog}
+                className="text-xs font-semibold text-slate-500 hover:text-indigo-600"
+              >
+                {loadingAccessLog ? 'Loading…' : 'Refresh'}
+              </button>
+            </div>
+            {accessLog === null ? (
+              <p className="mt-2 text-sm text-slate-500">Click refresh to load access attempts.</p>
+            ) : accessLog.length === 0 ? (
+              <p className="mt-2 text-sm text-slate-500">No attempts logged yet.</p>
+            ) : (
+              <ul className="mt-2 space-y-1 text-sm">
+                {accessLog.map((entry) => (
+                  <li key={entry.id} className="flex items-center gap-3 text-slate-600">
+                    <span className={entry.success ? 'text-emerald-600' : 'text-rose-600'}>
+                      {entry.success ? 'Success' : 'Failed'}
+                    </span>
+                    <span>{new Date(entry.createdAt).toLocaleString()}</span>
+                    <span className="text-slate-400">{entry.ipAddress ?? 'unknown IP'}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
+      )}
 
       {/* Images */}
       <section className="rounded-lg border border-slate-200 bg-white p-6">

--- a/apps/admin/app/lib/auth.ts
+++ b/apps/admin/app/lib/auth.ts
@@ -75,6 +75,75 @@ export const verifyAdminSessionToken = (token: string | undefined): boolean => {
 export const verifyAdminPassword = (password: string | null): boolean =>
   !!password && password === getAdminEnv().ADMIN_PASSWORD;
 
+const GALLERY_ACCESS_TOKEN_TTL_MS = 1000 * 60 * 60 * 24 * 90;
+
+type GalleryAccessTokenPayload = {
+  galleryId: string;
+  accessToken: string;
+  iat: number;
+  exp: number;
+};
+
+export const createGalleryAccessToken = (galleryId: string, accessToken: string): string => {
+  const env = getAdminEnv();
+  const now = Date.now();
+  const payload: GalleryAccessTokenPayload = {
+    galleryId,
+    accessToken,
+    iat: now,
+    exp: now + GALLERY_ACCESS_TOKEN_TTL_MS
+  };
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signature = sign(encodedPayload, env.AUTH_SECRET);
+
+  return `${encodedPayload}.${signature}`;
+};
+
+export const verifyGalleryAccessToken = (
+  token: string | undefined | null,
+  accessToken: string
+): string | null => {
+  const env = getAdminEnv();
+  if (!token) {
+    return null;
+  }
+
+  const [encodedPayload, signature] = token.split('.');
+
+  if (!encodedPayload || !signature) {
+    return null;
+  }
+
+  const expectedSignature = sign(encodedPayload, env.AUTH_SECRET);
+
+  const signatureBuffer = Buffer.from(signature);
+  const expectedBuffer = Buffer.from(expectedSignature);
+
+  if (signatureBuffer.length !== expectedBuffer.length) {
+    return null;
+  }
+
+  if (!timingSafeEqual(signatureBuffer, expectedBuffer)) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(base64UrlDecode(encodedPayload)) as GalleryAccessTokenPayload;
+
+    if (Date.now() > payload.exp) {
+      return null;
+    }
+
+    if (payload.accessToken !== accessToken) {
+      return null;
+    }
+
+    return payload.galleryId;
+  } catch {
+    return null;
+  }
+};
+
 export const getSessionCookieName = (): string => SESSION_COOKIE_NAME;
 
 export const getSessionMaxAgeSeconds = (): number => Math.floor(SESSION_MAX_AGE_MS / 1000);

--- a/apps/admin/app/lib/password.ts
+++ b/apps/admin/app/lib/password.ts
@@ -1,0 +1,27 @@
+import { randomBytes, scryptSync, timingSafeEqual } from 'node:crypto';
+
+const KEY_LENGTH = 64;
+
+export const hashPassword = (password: string): string => {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, KEY_LENGTH).toString('hex');
+
+  return `${salt}:${hash}`;
+};
+
+export const verifyPassword = (password: string, stored: string): boolean => {
+  const [salt, hash] = stored.split(':');
+
+  if (!salt || !hash) {
+    return false;
+  }
+
+  const hashBuffer = Buffer.from(hash, 'hex');
+  const candidateBuffer = scryptSync(password, salt, KEY_LENGTH);
+
+  if (hashBuffer.length !== candidateBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(hashBuffer, candidateBuffer);
+};

--- a/apps/evrydayarchive-web/app/api/private-galleries/[token]/route.ts
+++ b/apps/evrydayarchive-web/app/api/private-galleries/[token]/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+
+import { getServerEnv } from '../../../lib/env';
+
+export const POST = async (
+  req: Request,
+  { params }: { params: { token: string } }
+): Promise<Response> => {
+  const { ADMIN_API_BASE_URL } = getServerEnv();
+
+  const formData = await req.formData();
+  const password = formData.get('password');
+
+  const failureUrl = new URL(`/private/${params.token}`, req.url);
+  failureUrl.searchParams.set('error', '1');
+
+  if (typeof password !== 'string' || !password) {
+    return NextResponse.redirect(failureUrl, { status: 303 });
+  }
+
+  let adminRes: Response;
+  try {
+    adminRes = await fetch(
+      new URL(
+        `/api/public/private-galleries/${encodeURIComponent(params.token)}/verify`,
+        ADMIN_API_BASE_URL
+      ),
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password })
+      }
+    );
+  } catch (err) {
+    console.error('[private-galleries] Failed to reach admin API', err);
+    return NextResponse.redirect(failureUrl, { status: 303 });
+  }
+
+  const payload = await adminRes.json().catch(() => null);
+
+  if (!adminRes.ok || !payload?.ok) {
+    return NextResponse.redirect(failureUrl, { status: 303 });
+  }
+
+  const successUrl = new URL(`/private/${params.token}`, req.url);
+  const response = NextResponse.redirect(successUrl, { status: 303 });
+
+  response.cookies.set({
+    name: `private_access_${params.token}`,
+    value: payload.data.token,
+    httpOnly: true,
+    sameSite: 'lax',
+    path: `/private/${params.token}`
+  });
+
+  return response;
+};

--- a/apps/evrydayarchive-web/app/private/[token]/page.tsx
+++ b/apps/evrydayarchive-web/app/private/[token]/page.tsx
@@ -1,0 +1,141 @@
+import { cookies } from 'next/headers';
+import type { Metadata } from 'next';
+
+import { PublicApiError, fetchPrivateGallery, type PrivateGalleryDetail } from '@repo/core';
+
+import { getServerEnv } from '../../lib/env';
+import { Frame } from '../../components/frame';
+import { Placard } from '../../components/placard';
+import Image from '../../components/img';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false }
+};
+
+const cookieName = (token: string) => `private_access_${token}`;
+
+const PrivateGalleryPage = async ({
+  params,
+  searchParams
+}: {
+  params: { token: string };
+  searchParams?: { error?: string };
+}) => {
+  const { ADMIN_API_BASE_URL } = getServerEnv();
+  const accessToken = cookies().get(cookieName(params.token))?.value;
+
+  let gallery: PrivateGalleryDetail | null = null;
+
+  if (accessToken) {
+    try {
+      gallery = await fetchPrivateGallery(ADMIN_API_BASE_URL, params.token, accessToken, {
+        cache: 'no-store'
+      });
+    } catch (error) {
+      if (!(error instanceof PublicApiError && error.status === 401)) {
+        console.warn('[private-gallery] Failed to load gallery.', error);
+      }
+    }
+  }
+
+  if (!gallery) {
+    const showError = searchParams?.error === '1';
+
+    return (
+      <main className="flex min-h-screen items-center justify-center px-4 py-16">
+        <div className="w-full max-w-md rounded-card border border-border bg-surface p-8">
+          <h1 className="mb-2 text-xl font-semibold text-ink">Private gallery</h1>
+          <p className="mb-6 text-sm text-ink-muted">
+            This gallery is password-protected. Enter the password you were given to view it.
+          </p>
+          <form
+            method="post"
+            action={`/api/private-galleries/${params.token}`}
+            className="space-y-4"
+          >
+            <label className="flex flex-col gap-2 text-sm font-medium text-ink">
+              Password
+              <input
+                name="password"
+                type="password"
+                autoComplete="off"
+                required
+                className="rounded-md border border-border px-3 py-2 text-sm"
+              />
+            </label>
+            {showError && (
+              <p className="text-sm text-red-600" role="alert">
+                Incorrect password. Please try again.
+              </p>
+            )}
+            <button
+              type="submit"
+              className="w-full rounded-card bg-accent px-6 py-3 text-sm font-medium text-white transition-opacity duration-fast hover:opacity-90"
+            >
+              View gallery
+            </button>
+          </form>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="px-4 py-16 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-5xl">
+        <header className="mb-16 max-w-2xl">
+          <p className="mb-2 text-xs font-medium uppercase tracking-widest text-ink-faint">
+            {gallery.location ?? 'Private gallery'}
+          </p>
+          <h1 className="mb-5 text-4xl font-semibold tracking-tight text-ink sm:text-5xl">
+            {gallery.title}
+          </h1>
+          {gallery.description && (
+            <p className="text-base leading-relaxed text-ink-muted">{gallery.description}</p>
+          )}
+        </header>
+
+        {gallery.images.length === 0 ? (
+          <div className="py-20 text-center">
+            <p className="text-sm text-ink-faint">No images have been added yet.</p>
+          </div>
+        ) : (
+          <div className="columns-1 gap-8 sm:columns-2">
+            {gallery.images.map((image, index) => (
+              <figure key={image.id} className="mb-8 break-inside-avoid">
+                <Frame>
+                  <div
+                    className="relative w-full overflow-hidden rounded-sm bg-sun"
+                    style={{
+                      aspectRatio:
+                        image.width && image.height ? `${image.width} / ${image.height}` : '3 / 2'
+                    }}
+                  >
+                    <Image
+                      src={image.src}
+                      alt={image.alt}
+                      fill
+                      className="object-cover"
+                      sizes="(min-width: 1024px) 512px, (min-width: 640px) 50vw, 100vw"
+                      loading={index < 2 ? 'eager' : 'lazy'}
+                    />
+                  </div>
+                </Frame>
+
+                {image.caption && (
+                  <figcaption className="mt-3 pl-1">
+                    <Placard title={image.caption} size="sm" />
+                  </figcaption>
+                )}
+              </figure>
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+};
+
+export default PrivateGalleryPage;

--- a/apps/evrydayarchive-web/app/robots.ts
+++ b/apps/evrydayarchive-web/app/robots.ts
@@ -4,7 +4,8 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
-      allow: '/'
+      allow: '/',
+      disallow: '/private'
     },
     host: 'https://www.evrydayarchive.co',
     sitemap: 'https://www.evrydayarchive.co/sitemap.xml'

--- a/apps/evrydayarchive-web/middleware.ts
+++ b/apps/evrydayarchive-web/middleware.ts
@@ -13,8 +13,13 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Pass through the coming-soon page, API routes, and any static file (has a file extension)
-  if (pathname === '/coming-soon' || pathname.startsWith('/api/') || /\.\w+$/.test(pathname)) {
+  // Pass through the coming-soon page, API routes, private gallery links, and any static file
+  if (
+    pathname === '/coming-soon' ||
+    pathname.startsWith('/api/') ||
+    pathname.startsWith('/private/') ||
+    /\.\w+$/.test(pathname)
+  ) {
     return NextResponse.next();
   }
 

--- a/packages/core/src/api/errors.ts
+++ b/packages/core/src/api/errors.ts
@@ -6,6 +6,7 @@ export const apiErrorStatusMap: Record<ApiErrorCode, number> = {
   FORBIDDEN: 403,
   NOT_FOUND: 404,
   CONFLICT: 409,
+  TOO_MANY_REQUESTS: 429,
   INTERNAL: 500
 };
 

--- a/packages/core/src/api/publicGalleries.ts
+++ b/packages/core/src/api/publicGalleries.ts
@@ -1,8 +1,10 @@
 import {
   GalleryDetailSchema,
   GalleryListResponseSchema,
+  PrivateGalleryDetailSchema,
   type GalleryDetail,
-  type GalleryListItem
+  type GalleryListItem,
+  type PrivateGalleryDetail
 } from '../schemas/gallery';
 
 export class PublicApiError extends Error {
@@ -77,6 +79,38 @@ export const fetchPublicGalleryDetail = async (
   if (!parsed.success) {
     throw new PublicApiError(
       'Gallery detail response did not match the expected schema.',
+      response.status,
+      parsed.error.format()
+    );
+  }
+
+  return parsed.data;
+};
+
+export const fetchPrivateGallery = async (
+  baseUrl: string,
+  token: string,
+  accessToken: string,
+  init?: PublicFetchOptions
+): Promise<PrivateGalleryDetail> => {
+  const url = new URL(`/api/public/private-galleries/${encodeURIComponent(token)}`, baseUrl);
+  const response = await fetch(url, {
+    ...init,
+    method: 'GET',
+    headers: { ...init?.headers, Authorization: `Bearer ${accessToken}` }
+  });
+
+  if (!response.ok) {
+    const details = await parseJson(response).catch(() => undefined);
+    throw new PublicApiError('Failed to load private gallery.', response.status, details);
+  }
+
+  const payload = await parseJson(response);
+  const parsed = PrivateGalleryDetailSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    throw new PublicApiError(
+      'Private gallery response did not match the expected schema.',
       response.status,
       parsed.error.format()
     );

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -4,6 +4,7 @@ export type ApiErrorCode =
   | 'FORBIDDEN'
   | 'NOT_FOUND'
   | 'CONFLICT'
+  | 'TOO_MANY_REQUESTS'
   | 'INTERNAL';
 
 export type ApiError = {

--- a/packages/core/src/schemas/gallery.ts
+++ b/packages/core/src/schemas/gallery.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const GalleryStatusSchema = z.enum(['DRAFT', 'PUBLISHED', 'ARCHIVED']);
+export const GalleryStatusSchema = z.enum(['DRAFT', 'PUBLISHED', 'ARCHIVED', 'PRIVATE']);
 export type GalleryStatus = z.infer<typeof GalleryStatusSchema>;
 
 export const GalleryCreateSchema = z.object({
@@ -12,7 +12,8 @@ export const GalleryCreateSchema = z.object({
   description: z.string().optional(),
   location: z.string().optional(),
   order: z.number().int().min(0).optional(),
-  featured: z.boolean().optional()
+  featured: z.boolean().optional(),
+  password: z.string().min(4).optional()
 });
 
 export const GalleryUpdateSchema = GalleryCreateSchema.partial();
@@ -84,3 +85,33 @@ export const GalleryDetailSchema = z.object({
 export type GalleryListItem = z.infer<typeof GalleryListItemSchema>;
 export type GalleryListResponse = z.infer<typeof GalleryListResponseSchema>;
 export type GalleryDetail = z.infer<typeof GalleryDetailSchema>;
+
+export const PrivateGalleryVerifySchema = z.object({
+  password: z.string().min(1)
+});
+
+export const PrivateGalleryVerifyResponseSchema = z.object({
+  token: z.string().min(1)
+});
+
+export const PrivateGalleryDetailSchema = z.object({
+  id: z.string(),
+  accessToken: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  location: z.string().nullable(),
+  images: z.array(GalleryImageSchema)
+});
+
+export type PrivateGalleryDetail = z.infer<typeof PrivateGalleryDetailSchema>;
+
+export const GalleryAccessLogEntrySchema = z.object({
+  id: z.string(),
+  success: z.boolean(),
+  ipAddress: z.string().nullable(),
+  userAgent: z.string().nullable(),
+  createdAt: z.string()
+});
+
+export const GalleryAccessLogResponseSchema = z.array(GalleryAccessLogEntrySchema);
+export type GalleryAccessLogEntry = z.infer<typeof GalleryAccessLogEntrySchema>;

--- a/packages/db/prisma/migrations/20260807194330_add_private_galleries/migration.sql
+++ b/packages/db/prisma/migrations/20260807194330_add_private_galleries/migration.sql
@@ -1,0 +1,31 @@
+-- AlterEnum
+ALTER TYPE "GalleryStatus" ADD VALUE 'PRIVATE';
+
+-- AlterTable
+ALTER TABLE "Gallery" ADD COLUMN     "accessToken" TEXT,
+ADD COLUMN     "passwordHash" TEXT;
+
+-- CreateTable
+CREATE TABLE "GalleryAccessLog" (
+    "id" TEXT NOT NULL,
+    "galleryId" TEXT NOT NULL,
+    "success" BOOLEAN NOT NULL,
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "GalleryAccessLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "GalleryAccessLog_galleryId_idx" ON "GalleryAccessLog"("galleryId");
+
+-- CreateIndex
+CREATE INDEX "GalleryAccessLog_galleryId_createdAt_idx" ON "GalleryAccessLog"("galleryId", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Gallery_accessToken_key" ON "Gallery"("accessToken");
+
+-- AddForeignKey
+ALTER TABLE "GalleryAccessLog" ADD CONSTRAINT "GalleryAccessLog_galleryId_fkey" FOREIGN KEY ("galleryId") REFERENCES "Gallery"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -12,6 +12,7 @@ enum GalleryStatus {
   DRAFT
   PUBLISHED
   ARCHIVED
+  PRIVATE
 }
 
 enum PackageStatus {
@@ -55,19 +56,35 @@ enum BookingRequestStatus {
 }
 
 model Gallery {
-  id          String        @id @default(cuid())
-  slug        String        @unique
-  title       String
-  description String?
-  location    String?
-  status      GalleryStatus @default(DRAFT)
-  order       Int           @default(0)
-  featured    Boolean       @default(false)
-  publishedAt DateTime?
-  createdAt   DateTime      @default(now())
-  updatedAt   DateTime      @updatedAt
-  images      GalleryImage[]
-  reviews     Review[]
+  id           String        @id @default(cuid())
+  slug         String        @unique
+  title        String
+  description  String?
+  location     String?
+  status       GalleryStatus @default(DRAFT)
+  order        Int           @default(0)
+  featured     Boolean       @default(false)
+  publishedAt  DateTime?
+  accessToken  String?       @unique
+  passwordHash String?
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+  images       GalleryImage[]
+  reviews      Review[]
+  accessLogs   GalleryAccessLog[]
+}
+
+model GalleryAccessLog {
+  id        String   @id @default(cuid())
+  galleryId String
+  success   Boolean
+  ipAddress String?
+  userAgent String?
+  createdAt DateTime @default(now())
+  gallery   Gallery  @relation(fields: [galleryId], references: [id], onDelete: Cascade)
+
+  @@index([galleryId])
+  @@index([galleryId, createdAt])
 }
 
 model ImageAsset {


### PR DESCRIPTION
## Summary
- Adds a `PRIVATE` gallery status (reusing the existing Gallery/ImageAsset/Cloudinary pipeline) with a per-gallery password and unguessable access token, served at `/private/[token]` on evrydayarchive-web.
- Visitors unlock with a password verified server-side by admin, receive a signed, session-only cookie (cleared when the browser closes), and every attempt (success/fail) is logged to a new `GalleryAccessLog` table, viewable from the admin gallery editor.
- Private galleries are excluded from the public API, sitemap, and `robots.txt`, and the page ships a `noindex, nofollow` meta tag.
- A DB migration (`20260807194330_add_private_galleries`) has already been applied to the shared dev/prod Neon database.

## Test plan
- [x] `pnpm format` / `pnpm lint` / `pnpm typecheck` / `pnpm build` all pass
- [x] New vitest suites for the verify/get private-gallery routes pass, existing admin route tests unaffected
- [x] Manual e2e against the dev DB: created a `PRIVATE` gallery via the admin API, confirmed wrong password is rejected + logged, correct password unlocks + logs success, cookie has no `Expires`/`Max-Age`, gallery is absent from `/sitemap.xml` and `/api/public/galleries`, `/robots.txt` disallows `/private`, and the private page renders `<meta name="robots" content="noindex, nofollow">`
- [ ] Manual click-through in a browser (incognito) before sharing a real link with a client

🤖 Generated with [Claude Code](https://claude.com/claude-code)