### PR TITLE
Add Q3/Q4 roadmap and Gallery Experience V2 spec

### DIFF
--- a/requirements/gallery-experience-v2-roadmap.md
+++ b/requirements/gallery-experience-v2-roadmap.md
@@ -1,0 +1,104 @@
+# Roadmap: Gallery Experience V2
+
+**Scope:** `apps/evrydayarchive-web` (portfolio rendering), `apps/admin` (gallery authoring), `packages/db` (schema), `packages/core` (schemas)
+**Status:** Scoping — no phase started as of 2026-08-07
+**Horizon:** Q3/Q4, multi-PR
+
+---
+
+## Context
+
+Portfolio galleries currently render as a uniform two-column CSS-columns masonry (`apps/evrydayarchive-web/app/portfolio/[slug]/page.tsx`), driven by nothing more than `GalleryImage.order`. That's a reasonable v1, but it treats every gallery as an undifferentiated bag of photos in a fixed grid — no curatorial voice, no room for context, and mobile is just the same grid collapsed to one column.
+
+The goal of V2 is to make a gallery feel like an intentionally composed exhibit — closer to a photo essay or a real gallery walkthrough than a photo grid — while staying inside the site's existing "art gallery / museum crossed with archival" language (paper canvas, grain, frames, Placard-style labels — see `apps/evrydayarchive-web/app/globals.css` and `tailwind.config.ts` for the existing token/motion vocabulary this should extend, not replace).
+
+This document exists so the work can be picked up, handed off, or resumed across multiple PRs without re-deriving the shape of the problem each time. It is a living document — expect it to change as each phase surfaces things we didn't know yet.
+
+---
+
+## What a gallery is made of (V2 mental model)
+
+Conversation with Reed (2026-08-07) converged on a gallery being composed of, in principle:
+
+1. **Sections** — a gallery may be divided into distinct parts, each potentially with its own identity, rather than one continuous scroll of photos.
+2. **Wall text** — real documentation/context, or reflective prompts ("questions to ponder") — museum-didactic-panel style prose, not a photo caption. May belong to a section or to the gallery as a whole; not necessarily anchored to one specific image.
+3. **Image-level captions/plaques** — short label-style info tied to an individual photo (the existing `Placard` component is the right building block here).
+4. **Per-image layout intent** — how a given image is presented: size/alignment on desktop; fit/offset within a full-bleed frame on mobile.
+5. **(Future / unscoped) Interactive elements** — some mechanism for viewer engagement. Explicitly not designed yet; flagged so it isn't forgotten, not because it's next.
+
+Desktop and mobile are **two different renderings of the same authored intent**, not one derived from the other via responsive CSS:
+
+- **Desktop** — an editorial composition: sections, varied image sizes/alignment within a constrained grid vocabulary, wall text blocks interspersed between images, image plaques positioned beside/under frames (mirroring how `Frame`'s existing `placard`/`placardPosition` props already model a real museum label sitting next to, not on top of, the work).
+- **Mobile** — a full-bleed, vertical scroll-snap viewer (TikTok-adjacent mechanic): each scroll-snap point is dominated by one image at near-full viewport, with a per-image fit mode (true full-bleed / inset-offset / smaller-in-frame) and text (caption or wall text) integrated into that same vertical rhythm rather than living in a side panel.
+
+---
+
+## Guiding principles
+
+- **Design toward the real V2, not the cheapest slice.** Phases below are a sequencing strategy, not a scope-cutting exercise — the goal is the full end state, built incrementally.
+- **Additive and opt-in.** Existing galleries keep rendering through the current masonry unchanged. New fields/rendering paths only activate where explicitly authored, so nothing live breaks mid-rollout. A likely mechanism: a `layoutMode` flag on `Gallery` (`CLASSIC` vs the new mode) — TBD in Phase A.
+- **Prove the rendering vocabulary before building tooling for it.** A visual admin builder is expensive to build and easy to build wrong for a layout language nobody has stress-tested. Validate the data model and rendering engine against real galleries first, even with a bare-bones (dropdown) admin interface, before investing in a builder UI.
+- **Keep the layout vocabulary closed, not freeform.** A small enum of size/alignment/fit roles is dramatically easier to render predictably (and to art-direct from admin) than free pixel/position values. Expand the vocabulary only when a real gallery needs a role that doesn't exist yet.
+- **This has a content dependency, not just an engineering one.** Wall text and section framing are editorial/creative work — the roadmap should assume Reed is writing real museum-style text for pilot galleries alongside each phase, not that it appears for free.
+
+---
+
+## Phases
+
+### Phase A — Data model foundations
+Extend the schema to carry curatorial intent without touching how anything renders yet.
+
+- Add a way to group images into **sections** within a gallery (new model or a nullable `sectionId`/section label on `GalleryImage` — TBD).
+- Add a **wall text** content type — distinct from `ImageAsset.caption` (which stays as the short label/plaque text) — attachable to a gallery or a section, supporting real prose length.
+- Extend `GalleryImage` with closed-vocabulary layout roles: a desktop size/alignment role, and a mobile fit/offset role.
+- Add the `layoutMode` (or equivalent) opt-in flag so existing galleries are provably unaffected.
+- Sanitize/shape all of this through `packages/core` Zod schemas per existing convention.
+
+**Exit criteria:** schema + migration merged, admin can set the new fields via raw form controls (no visual polish required yet), nothing on the live public site has changed.
+
+### Phase B — Desktop rendering engine
+- Build the compositor that interprets section/order/size/alignment/wall-text into an actual layout — CSS Grid with a fixed column count and size roles mapped to spans is the likely mechanism, versus true freeform positioning.
+- Ship against 1–2 real galleries, hand-authored through Phase A's bare admin controls, to pressure-test the vocabulary against real (imperfect) photos before anyone builds tooling around it.
+- Expect to discover edge cases here: orphaned single images in a row, portrait photos forced into a role that assumes landscape, wall text overflow at certain spans.
+
+**Exit criteria:** at least one real gallery live in V2 layout mode, holding up across common desktop widths.
+
+### Phase C — Mobile full-bleed scroll-snap viewer
+- Separate rendering path: CSS scroll-snap, one dominant image per snap point, per-image fit mode (full-bleed / inset / smaller-in-frame), text integrated into the vertical rhythm.
+- Likely to surface new questions about how sections and wall text translate to a vertical feed metaphor that don't have answers yet — treat this as its own mini design pass once Phase A's data model is proven on desktop, not a mechanical port.
+
+**Exit criteria:** the same pilot gallery(ies) from Phase B have a working, on-brand mobile experience distinct from — not a squeeze of — the desktop layout.
+
+### Phase D — Admin visual builder
+- A drag/arrange authoring interface: see sections, image order, size/alignment, and text placement roughly as they'll render, instead of picking enum values from dropdowns and republishing to check.
+- Largest standalone investment in this roadmap. Deserves its own spec once Phases A–C have validated what the vocabulary actually needs to express — building a visual editor for a layout language that's still shifting is wasted work.
+
+**Exit criteria:** Reed can compose a new V2 gallery end-to-end without touching raw form dropdowns or guessing at render output.
+
+### Phase E — Interactive elements (unscoped / future)
+- Flagged from the original conversation as a long-term idea for viewer engagement within a gallery. No shape yet — needs its own ideation pass once A–D exist to build on. Not a near-term commitment.
+
+---
+
+## Where the risk actually lives
+
+- **Combinatorial visual QA**, not the migration. Image aspect ratio × size role × alignment × wall-text presence × viewport width is a large surface — this is inherent to the feature, not a sign something's wrong, but it means Phase B/C need real photos and real widths, not a handful of happy-path screenshots.
+- **Admin builder scope creep** (Phase D) is the single biggest way this roadmap could balloon. Explicitly sequenced last and behind a design pass for exactly that reason.
+- **Schema churn risk if Phase A locks in the wrong vocabulary too early** — mitigated by proving it against real content in Phase B before Phase D depends on it.
+- **Not a risk to what's live today** — the opt-in `layoutMode` approach means this can ship incrementally, gallery by gallery, with the existing masonry as a permanent fallback for anything not migrated.
+
+---
+
+## Open questions to resolve (in order of when they'll bite)
+
+1. **Sections** — a real structural concept with their own identity/heading, or just a visual grouping cue with no independent presence? Affects Phase A's schema shape directly.
+2. **Wall text placement** — can a section be text-only (no images), or does wall text always accompany at least one image? Affects both the data model and the desktop compositor.
+3. **Mobile snap granularity** — is a scroll-snap point always exactly one image, or can a "spread" (e.g. a diptych) occupy one snap point? Affects Phase C's rendering model.
+4. **Is `CLASSIC` masonry a permanent supported mode**, or a deprecated stepping stone once V2 proves out? Affects how much long-term maintenance burden we accept from running two renderers.
+5. **Interactive elements (Phase E)** — roughly what kind of engagement is Reed picturing? Not urgent, but worth capturing early thoughts before they're lost.
+
+---
+
+## Change log
+
+- 2026-08-07: Initial roadmap drafted from conversation with Reed, following the shipped private-gallery-sharing feature.

--- a/requirements/gallery-experience-v2-roadmap.md
+++ b/requirements/gallery-experience-v2-roadmap.md
@@ -46,6 +46,7 @@ Desktop and mobile are **two different renderings of the same authored intent**,
 ## Phases
 
 ### Phase A — Data model foundations
+
 Extend the schema to carry curatorial intent without touching how anything renders yet.
 
 - Add a way to group images into **sections** within a gallery (new model or a nullable `sectionId`/section label on `GalleryImage` — TBD).
@@ -57,6 +58,7 @@ Extend the schema to carry curatorial intent without touching how anything rende
 **Exit criteria:** schema + migration merged, admin can set the new fields via raw form controls (no visual polish required yet), nothing on the live public site has changed.
 
 ### Phase B — Desktop rendering engine
+
 - Build the compositor that interprets section/order/size/alignment/wall-text into an actual layout — CSS Grid with a fixed column count and size roles mapped to spans is the likely mechanism, versus true freeform positioning.
 - Ship against 1–2 real galleries, hand-authored through Phase A's bare admin controls, to pressure-test the vocabulary against real (imperfect) photos before anyone builds tooling around it.
 - Expect to discover edge cases here: orphaned single images in a row, portrait photos forced into a role that assumes landscape, wall text overflow at certain spans.
@@ -64,18 +66,21 @@ Extend the schema to carry curatorial intent without touching how anything rende
 **Exit criteria:** at least one real gallery live in V2 layout mode, holding up across common desktop widths.
 
 ### Phase C — Mobile full-bleed scroll-snap viewer
+
 - Separate rendering path: CSS scroll-snap, one dominant image per snap point, per-image fit mode (full-bleed / inset / smaller-in-frame), text integrated into the vertical rhythm.
 - Likely to surface new questions about how sections and wall text translate to a vertical feed metaphor that don't have answers yet — treat this as its own mini design pass once Phase A's data model is proven on desktop, not a mechanical port.
 
 **Exit criteria:** the same pilot gallery(ies) from Phase B have a working, on-brand mobile experience distinct from — not a squeeze of — the desktop layout.
 
 ### Phase D — Admin visual builder
+
 - A drag/arrange authoring interface: see sections, image order, size/alignment, and text placement roughly as they'll render, instead of picking enum values from dropdowns and republishing to check.
 - Largest standalone investment in this roadmap. Deserves its own spec once Phases A–C have validated what the vocabulary actually needs to express — building a visual editor for a layout language that's still shifting is wasted work.
 
 **Exit criteria:** Reed can compose a new V2 gallery end-to-end without touching raw form dropdowns or guessing at render output.
 
 ### Phase E — Interactive elements (unscoped / future)
+
 - Flagged from the original conversation as a long-term idea for viewer engagement within a gallery. No shape yet — needs its own ideation pass once A–D exist to build on. Not a near-term commitment.
 
 ---

--- a/requirements/q3-q4-2026-roadmap.md
+++ b/requirements/q3-q4-2026-roadmap.md
@@ -1,0 +1,144 @@
+# Q3/Q4 2026 Roadmap — Evryday Archive Co
+
+**Status:** Draft — scoped from conversation with Reed, 2026-08-07
+**Purpose:** A single index of the initiatives planned for Q3/Q4, each at whatever depth it currently warrants. Some already have detailed specs (linked below); others are one paragraph until they're scoped properly. This document tracks status and rough priority tiers — it does not replace a dedicated spec once an initiative is ready for one.
+
+This sits alongside, not instead of, existing GitHub issues/PRs — where one already exists, this points to it rather than duplicating it.
+
+**This is a living document, not a locked schedule.** The ordering below is a starting opinion, not a commitment — Reed calls what happens when, and that call is expected to shift as work lands, priorities change, or an initiative turns out bigger/smaller than it looked from the outside. Revisit and re-sequence freely; update the change log when priority calls change materially.
+
+---
+
+## Initiatives
+
+### 1. Gallery Experience V2
+**Detailed spec:** [`gallery-experience-v2-roadmap.md`](./gallery-experience-v2-roadmap.md)
+**Status:** Scoping complete, no phase started
+**Size:** Largest single initiative in this roadmap — multi-PR, phased A–E
+
+Sections, wall text, per-image captions/plaques, curated desktop layout, full-bleed mobile scroll-snap viewer, and eventually an admin visual builder. See the linked doc for the full phase breakdown, risks, and open questions.
+
+---
+
+### 2. Land gallery description/headline/shoot-date
+**Reference:** [PR #92](https://github.com/rmcilwain6/brand-websites/pull/92) — `feat/gallery-metadata`
+**Status:** Open PR, ready for review/test-plan sign-off
+**Size:** Small — already built
+
+Surfaces `description`, adds `headline` and `shootDate` to galleries end-to-end (schema → admin → API → frontend). Purely a matter of finishing the test plan and merging. Worth doing first — it's a dependency-free, already-done piece, and the wall-text/caption concepts in Gallery Experience V2 (Initiative 1) will build on the same surfaced-metadata pattern this PR establishes.
+
+---
+
+### 3. Dynamic OG image generation
+**Reference:** [Issue #86](https://github.com/rmcilwain6/brand-websites/issues/86)
+**Status:** Scoped, not started
+**Size:** Small–medium, self-contained
+
+Per-page Open Graph images via Next.js `ImageResponse` — gallery pages get a cover-image + title + location card instead of the current blank preview when shared to iMessage/Slack/social. Already has a clear proposed approach in the issue. Natural prerequisite for Initiative 4 below.
+
+**Follow-on, not in this pass:** [Issue #87](https://github.com/rmcilwain6/brand-websites/issues/87) (in-gallery social share button + brandable downloadable client card) explicitly depends on #86's infrastructure. Worth doing in the same quarter once #86 lands, but keep them as separate PRs — #87 has its own open questions (fixed template vs. client-chosen images, per-client private share tokens) that shouldn't block #86.
+
+---
+
+### 4. Frame wall refresh
+**Status:** Not started
+**Size:** Depends on how far the rework goes — treat as more than an asset swap
+
+Reed's read: this isn't just dropping in newer photos. The rolling-hero mechanic itself (`rolling-hero.tsx`, hardcoded image set in `public/images/top-brand-images/*.webp`, currently **off** by default behind `ROLLING_HERO`) needs a real look at both the content and the mechanics before it's worth turning on — new images alone won't be enough if the underlying motion/behavior isn't already right.
+
+**Open questions:** what specifically feels off about the current mechanics (pacing, drag behavior, the fixed-text variant vs. plain rolling)? And separately: keep the image set hardcoded in the repo, or make it admin-managed so future refreshes aren't a code change?
+
+---
+
+### 4a. Existing prototypes generally need a design + mechanics pass, not just wiring
+**Status:** Cross-cutting note
+
+A theme across Initiatives 4, 6, and 7: code existing in the repo (rolling hero, `FilingCabinet`, the `/inquire` questionnaire) is not the same as those features being finished. Each was built to a point and left — the interaction design, visual polish, and in some cases the underlying mechanics still need real evaluation and iteration, not just a data-wiring pass. Treat "already built" in the notes below as "a starting point that's been sitting," not "mostly done."
+
+---
+
+### 5. Home page "meet the photographer" intro
+**Status:** Not started
+**Size:** Small — content/design, no backend
+
+Today this is the plain-text "Photographer philosophy" block (`page.tsx`, Section 2) — a literary zigzag paragraph ending in a quiet text link ("Meet the photographer →"). Reed wants a photo added and the section made brighter, friendlier, and more clearly clickable — likely means treating it more like an inviting card/CTA than a subtle text link. Small, self-contained, good candidate for an early quarter win once a photo is chosen.
+
+---
+
+### 6. Dynamic, interactive reviews on the home page
+**Status:** Not started; a candidate building block exists but isn't assumed sufficient
+**Size:** Medium — treat as a real design pass, not a drop-in
+
+The home page's testimonials are a hardcoded 3-quote array (`TESTIMONIALS` in `page.tsx`) explicitly marked as a placeholder. There's also `FilingCabinet` (`app/components/filing-cabinet.tsx`) — a tabbed review browser with real data fetching (`fetchPublicReviews`) and bespoke tab-transition animations — sitting unused in the codebase. That's a useful starting point, not a finished answer: per Reed, what exists isn't necessarily where it needs to land design- or mechanics-wise, and "more engagement/interaction" may call for something beyond what `FilingCabinet` currently does. Scope this as evaluate-and-likely-rework, with retiring the static array as the one certain outcome.
+
+**Open question:** does the filing-cabinet interaction (or a reworked version of it) satisfy "more engagement," or is Reed picturing something else entirely (filtering by session type, linking out to the source gallery more prominently, something more exploratory)?
+
+---
+
+### 7. `/inquire` interactive questionnaire
+**Status:** UI exists but isn't considered finished; recommendation engine is a stub
+**Size:** Medium–large — real UX/mechanics work plus a data-wiring dependency
+
+An interactive questionnaire already exists (`questionnaire.tsx`, 686 lines, built against `requirements/guided-questionaire.md`), but per Reed it isn't yet where it needs to be — this should be scoped as genuinely building out `/inquire`, not just patching the one known gap. That known gap is real too: `recommendation.ts` isn't wired to real package/pricing data, which is the same underlying gap as "Package Builder dynamic price calculation" (tracked in the stale root `ROADMAP.md`) — those two should be scoped and built together rather than each reinventing pricing logic. But the data wiring is necessary, not sufficient; expect a UX/interaction review of the questionnaire itself as part of this initiative.
+
+---
+
+### 8. Custom page view / click tracking in admin
+**Status:** Not started, least defined of this list
+**Size:** Unclear until scoped — could range from small to a real sub-project
+
+Reed wants visibility beyond Vercel's free-tier analytics, surfaced in the admin dashboard. This is the one item here with a genuine build-vs-buy fork worth deciding explicitly before writing code:
+
+- **Self-hosted/embedded tool** (e.g. Plausible, Umami, PostHog) — fastest to working dashboards, less custom, but another service/dependency to run and another login, and less native inside the existing admin UI.
+- **Custom-built** — a `PageView`/`ClickEvent` table, a lightweight client-side beacon, and a new admin "Analytics" section rendering it. Fully native and exactly the shape Reed wants, but is a real mini-project: needs a decision on what's tracked (page views only, or specific CTA clicks too), retention/volume handling, and basic privacy consideration (no PII, IP handling akin to what the private-gallery access log already does).
+
+Given the size of everything else in this quarter, this is a good candidate for a short, dedicated scoping conversation of its own before deciding which path — recommend not starting it opportunistically alongside the others.
+
+---
+
+## Priority tiers (Reed's call, revisited as we go)
+
+Grouped rather than strictly numbered — within a tier, order is genuinely interchangeable and should follow whatever Reed's actually in the mood to tackle or has fresh input on (a new photo arrives, a design idea clicks, etc.). Tiers themselves can be reshuffled too; this is the starting opinion, not the plan.
+
+**Land now / lowest friction**
+- PR #92 — already built, just needs the test plan closed out.
+
+**Near-term, self-contained, don't depend on anything else landing first**
+- Frame wall (Initiative 4) — pending Reed's read on what specifically needs to change mechanically.
+- Home page intro redesign (Initiative 5).
+- Dynamic OG images (Issue #86).
+
+**Real design/rework passes — bigger than they look from the outside**
+- Home page reviews (Initiative 6).
+- `/inquire` questionnaire + recommendation engine (Initiative 7), bundled with Package Builder pricing.
+
+**Anchor project — multi-quarter, start when ready**
+- Gallery Experience V2 (Initiative 1), Phase A.
+
+**Needs its own scoping conversation before it has a place in sequence**
+- Admin analytics (Initiative 8).
+
+This grouping is meant to be argued with — if something in "near-term" turns out to need real rework once Reed digs in (the way the frame wall and reviews already did), it moves down a tier without needing to renegotiate the whole document.
+
+---
+
+## Not included in this pass (existing untriaged backlog)
+
+These have open GitHub issues but weren't part of tonight's conversation — listed so this roadmap doesn't accidentally hide them, not because they're being deprioritized:
+
+- [#89](https://github.com/rmcilwain6/brand-websites/issues/89) — client payment portal (Stripe)
+- [#68](https://github.com/rmcilwain6/brand-websites/issues/68) — Playwright e2e test suite
+- [#66](https://github.com/rmcilwain6/brand-websites/issues/66) — `turbo-ignore` per-app Vercel builds (one-line config change)
+- [#53](https://github.com/rmcilwain6/brand-websites/issues/53) — no-JS / AI-agent discoverability audit
+- [#52](https://github.com/rmcilwain6/brand-websites/issues/52) — finish coming-soon page polish
+- [#43](https://github.com/rmcilwain6/brand-websites/issues/43) / [#42](https://github.com/rmcilwain6/brand-websites/issues/42) / [#41](https://github.com/rmcilwain6/brand-websites/issues/41) — site-wide photography presence, package builder carousel, package builder intro copy
+- [#38](https://github.com/rmcilwain6/brand-websites/issues/38) — transactional email (Resend) for inquiries
+- [#36](https://github.com/rmcilwain6/brand-websites/issues/36) — real Instagram link
+
+Also: the root `ROADMAP.md` is a whole-project tracker last updated 2026-03-21 and is now noticeably stale (predates private galleries, the process/FAQ rewrite, and everything in this document). Worth a separate pass to reconcile it once this quarter's priorities settle — not urgent tonight.
+
+---
+
+## Change log
+
+- 2026-08-07: Initial draft from conversation with Reed.

--- a/requirements/q3-q4-2026-roadmap.md
+++ b/requirements/q3-q4-2026-roadmap.md
@@ -12,6 +12,7 @@ This sits alongside, not instead of, existing GitHub issues/PRs — where one al
 ## Initiatives
 
 ### 1. Gallery Experience V2
+
 **Detailed spec:** [`gallery-experience-v2-roadmap.md`](./gallery-experience-v2-roadmap.md)
 **Status:** Scoping complete, no phase started
 **Size:** Largest single initiative in this roadmap — multi-PR, phased A–E
@@ -21,6 +22,7 @@ Sections, wall text, per-image captions/plaques, curated desktop layout, full-bl
 ---
 
 ### 2. Land gallery description/headline/shoot-date
+
 **Reference:** [PR #92](https://github.com/rmcilwain6/brand-websites/pull/92) — `feat/gallery-metadata`
 **Status:** Open PR, ready for review/test-plan sign-off
 **Size:** Small — already built
@@ -30,6 +32,7 @@ Surfaces `description`, adds `headline` and `shootDate` to galleries end-to-end 
 ---
 
 ### 3. Dynamic OG image generation
+
 **Reference:** [Issue #86](https://github.com/rmcilwain6/brand-websites/issues/86)
 **Status:** Scoped, not started
 **Size:** Small–medium, self-contained
@@ -41,6 +44,7 @@ Per-page Open Graph images via Next.js `ImageResponse` — gallery pages get a c
 ---
 
 ### 4. Frame wall refresh
+
 **Status:** Not started
 **Size:** Depends on how far the rework goes — treat as more than an asset swap
 
@@ -51,6 +55,7 @@ Reed's read: this isn't just dropping in newer photos. The rolling-hero mechanic
 ---
 
 ### 4a. Existing prototypes generally need a design + mechanics pass, not just wiring
+
 **Status:** Cross-cutting note
 
 A theme across Initiatives 4, 6, and 7: code existing in the repo (rolling hero, `FilingCabinet`, the `/inquire` questionnaire) is not the same as those features being finished. Each was built to a point and left — the interaction design, visual polish, and in some cases the underlying mechanics still need real evaluation and iteration, not just a data-wiring pass. Treat "already built" in the notes below as "a starting point that's been sitting," not "mostly done."
@@ -58,6 +63,7 @@ A theme across Initiatives 4, 6, and 7: code existing in the repo (rolling hero,
 ---
 
 ### 5. Home page "meet the photographer" intro
+
 **Status:** Not started
 **Size:** Small — content/design, no backend
 
@@ -66,6 +72,7 @@ Today this is the plain-text "Photographer philosophy" block (`page.tsx`, Sectio
 ---
 
 ### 6. Dynamic, interactive reviews on the home page
+
 **Status:** Not started; a candidate building block exists but isn't assumed sufficient
 **Size:** Medium — treat as a real design pass, not a drop-in
 
@@ -76,6 +83,7 @@ The home page's testimonials are a hardcoded 3-quote array (`TESTIMONIALS` in `p
 ---
 
 ### 7. `/inquire` interactive questionnaire
+
 **Status:** UI exists but isn't considered finished; recommendation engine is a stub
 **Size:** Medium–large — real UX/mechanics work plus a data-wiring dependency
 
@@ -84,6 +92,7 @@ An interactive questionnaire already exists (`questionnaire.tsx`, 686 lines, bui
 ---
 
 ### 8. Custom page view / click tracking in admin
+
 **Status:** Not started, least defined of this list
 **Size:** Unclear until scoped — could range from small to a real sub-project
 
@@ -101,21 +110,26 @@ Given the size of everything else in this quarter, this is a good candidate for 
 Grouped rather than strictly numbered — within a tier, order is genuinely interchangeable and should follow whatever Reed's actually in the mood to tackle or has fresh input on (a new photo arrives, a design idea clicks, etc.). Tiers themselves can be reshuffled too; this is the starting opinion, not the plan.
 
 **Land now / lowest friction**
+
 - PR #92 — already built, just needs the test plan closed out.
 
 **Near-term, self-contained, don't depend on anything else landing first**
+
 - Frame wall (Initiative 4) — pending Reed's read on what specifically needs to change mechanically.
 - Home page intro redesign (Initiative 5).
 - Dynamic OG images (Issue #86).
 
 **Real design/rework passes — bigger than they look from the outside**
+
 - Home page reviews (Initiative 6).
 - `/inquire` questionnaire + recommendation engine (Initiative 7), bundled with Package Builder pricing.
 
 **Anchor project — multi-quarter, start when ready**
+
 - Gallery Experience V2 (Initiative 1), Phase A.
 
 **Needs its own scoping conversation before it has a place in sequence**
+
 - Admin analytics (Initiative 8).
 
 This grouping is meant to be argued with — if something in "near-term" turns out to need real rework once Reed digs in (the way the frame wall and reviews already did), it moves down a tier without needing to renegotiate the whole document.


### PR DESCRIPTION
## Summary

Two planning documents, no code changes:

- `requirements/q3-q4-2026-roadmap.md` — master index of Q3/Q4 initiatives (Gallery Experience V2, landing PR #92, dynamic OG images, frame wall refresh, home page intro, home page reviews, `/inquire`, admin analytics), grouped into priority tiers rather than a fixed sequence, plus a pointer list of existing untriaged issues that weren't part of this pass.
- `requirements/gallery-experience-v2-roadmap.md` — phased spec (A–E) for the larger gallery redesign: sections, wall text, per-image captions/layout intent, desktop editorial compositor, mobile full-bleed scroll-snap viewer, and eventually an admin visual builder.

Both are living documents, expected to be revised as work lands and priorities shift.

## Test plan

- [x] N/A — documentation only, no code/schema/build changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)